### PR TITLE
All cryostat parts sensitive and enlarged cryostat back

### DIFF
--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_deadMaterial.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_deadMaterial.xml
@@ -12,6 +12,9 @@
   </info>
 
   <define>
+    <!-- Redefinition of a constant from Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectDimensions.xml -->
+    <constant name="BarECal_rmax" value="3700*mm"/>
+
     <!-- Inclination angle of the lead plates -->
     <constant name="InclinationAngle" value="50*degree"/>
     <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
@@ -20,7 +23,7 @@
     <!-- Air margin, thicknesses of cryostat and LAr bath -->
     <constant name="AirMarginThickness" value="0*mm"/>
     <constant name="CryoThicknessFront" value="50*mm"/>
-    <constant name="CryoThicknessBack" value="100*mm"/>
+    <constant name="CryoThicknessBack" value="1100*mm"/>
     <constant name="CryoThicknessSide" value="100*mm"/>
     <constant name="LArBathThicknessFront" value="10*mm"/>
     <constant name="LArBathThicknessBack" value="40*mm"/>
@@ -74,8 +77,8 @@
         <material name="Aluminum"/>
 	      <dimensions dz="BarCryoECal_dz" rmax1="BarCryoECal_rmax-CryoThicknessBack" rmax2="BarCryoECal_rmax" rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoThicknessFront"/>
 	      <front sensitive="true"/> <!-- inner wall of the cryostat -->
-	      <side sensitive="false"/> <!-- both sides of the cryostat -->
-	      <back sensitive="false"/> <!-- outer wall of the cryostat -->
+	      <side sensitive="true"/> <!-- both sides of the cryostat -->
+	      <back sensitive="true"/> <!-- outer wall of the cryostat -->
       </cryostat>
       <calorimeter name="EM_barrel">
 	<!-- offset defines the numbering of the modules: module==0 for phi=0 direction -->


### PR DESCRIPTION
Hello :)

this request modifies detector for upstream correction to be able to support downstream correction as well.
Redefinition of BarECal_rmax constant is required for enlargement of the back cryostat.
See https://github.com/HEP-FCC/k4SimGeant4/pull/9

Best,
Juraj