### PR TITLE
cmake: set CMAKE_CXX_STANDARD before finding dd4hep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,6 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 project(FCCDetectors)
 
 
-#---------------------------------------------------------------
-find_package(DD4hep)
-#---------------------------------------------------------------
 
 
 include(GNUInstallDirs)
@@ -29,6 +26,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 message(${CMAKE_MODULE_PATH})
 
 
+#---------------------------------------------------------------
+find_package(DD4hep)
+#---------------------------------------------------------------
 
 get_target_property(ddcore_lib DD4hep::DDCore LOCATION)
 get_filename_component(ddcore_loc ${ddcore_lib} DIRECTORY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 
 project(FCCDetectors)
 
-
-
-
 include(GNUInstallDirs)
 include(CTest)
 
+# CMake variable setup------------------------------------------
+# Default for install prefix
+# ``-DCMAKE_INSTALL_PREFIX=<location>`` when invoking CMake
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/InstallArea/ CACHE PATH
     "Install path prefix, prepended onto install directories." FORCE )
@@ -16,20 +16,18 @@ endif()
 # Set up C++ Standard
 # ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-
 if(NOT CMAKE_CXX_STANDARD MATCHES "14|17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
-message(${CMAKE_MODULE_PATH})
+# Find CMake scripts
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
-message(${CMAKE_MODULE_PATH})
 
-
-#---------------------------------------------------------------
+# Dependencies--------------------------------------------------
 find_package(DD4hep)
-#---------------------------------------------------------------
 
+
+# Environment  for tests----------------------------------------
 get_target_property(ddcore_lib DD4hep::DDCore LOCATION)
 get_filename_component(ddcore_loc ${ddcore_lib} DIRECTORY)
 function(k4_set_test_env _testname)
@@ -39,29 +37,19 @@ endforeach()
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_CURRENT_BINARY_DIR}:${ddcore_loc}:${_subdirs}:$ENV{LD_LIBRARY_PATH}")
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "ROOT_INCLUDE_PATH=${ddcore_loc}/../include:$ENV{ROOT_INCLUDE_PATH}")
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "DD4hepINSTALL=${ddcore_loc}/../")
-
 endfunction()
 
-
-
+# Subdirectories -----------------------------------------------
 add_subdirectory(Detector)
 
-# - install and export
+# Installation and export --------------------------------------
 install(FILES
   "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   )
-
-
-
-
-
 
 install(EXPORT ${PROJECT_NAME}Targets
   NAMESPACE ${PROJECT_NAME}::
   FILE "${PROJECT_NAME}Targets.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/"
   )
-
-#gaudi_install(CMAKE cmake/${PROJECT_NAME}Config.cmake)
-


### PR DESCRIPTION
Avoids a possible config error with cmake > 3.18 and dd4hep <= 1.20.1