### PR TITLE
Propagate upstream changes: Geant4Hits header removed in dd4hep

### DIFF
--- a/Detector/DetSensitive/include/DetSensitive/AggregateCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/AggregateCalorimeterSD.h
@@ -3,7 +3,7 @@
 
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 
 // FCCSW
 #include "DetCommon/Geant4CaloHit.h"

--- a/Detector/DetSensitive/include/DetSensitive/BirksLawCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/BirksLawCalorimeterSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_BIRKSLAWCALORIMETERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 
 // Geant
 #include "G4THitsCollection.hh"

--- a/Detector/DetSensitive/include/DetSensitive/FullParticleAbsorptionSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/FullParticleAbsorptionSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_FULLPARTICLEABSORPTIONSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 #include "DDSegmentation/Segmentation.h"
 
 // Geant

--- a/Detector/DetSensitive/include/DetSensitive/GflashCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/GflashCalorimeterSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_GFLASHCALORIMETERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 #include "DDSegmentation/Segmentation.h"
 
 // Geant

--- a/Detector/DetSensitive/include/DetSensitive/SimpleCalorimeterSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/SimpleCalorimeterSD.h
@@ -2,9 +2,7 @@
 #define DETSENSITIVE_SIMPLECALORIMETERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
-
-
+#include "DD4hep/Segmentations.h"
 
 // Geant
 #include "G4THitsCollection.hh"

--- a/Detector/DetSensitive/include/DetSensitive/SimpleDriftChamber.h
+++ b/Detector/DetSensitive/include/DetSensitive/SimpleDriftChamber.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_SIMPLEDRIFTCHAMBER_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 #include "DDSegmentation/Segmentation.h"
 
 // Geant

--- a/Detector/DetSensitive/include/DetSensitive/SimpleTrackerSD.h
+++ b/Detector/DetSensitive/include/DetSensitive/SimpleTrackerSD.h
@@ -2,7 +2,7 @@
 #define DETSENSITIVE_SIMPLETRACKERSD_H
 
 // DD4hep
-#include "DDG4/Geant4Hits.h"
+#include "DD4hep/Segmentations.h"
 
 // Geant
 #include "G4THitsCollection.hh"


### PR DESCRIPTION
The classes defined in this header are not used in any case, the include can just be replaced with another one that provides dd4hep::Segmentation