### PR TITLE
Saving generated detectors to build directory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,10 @@ generate-root:
     - ninja -k0 && ctest --output-on-failure
     - cd ..
     - mkdir -p detectors
-    - mv fccee_cld.root detectors/
-    - mv fccee_idea.root detectors/
-    - mv fccee_nlq.root detectors/
-    - mv fcchh_baseline.root detectors/
+    - mv build/fccee_cld.root detectors/
+    - mv build/fccee_idea.root detectors/
+    - mv build/fccee_nlq.root detectors/
+    - mv build/fcchh_baseline.root detectors/
   artifacts:
     paths:
       - detectors/*root

--- a/Detector/DetFCCeeCLD/CMakeLists.txt
+++ b/Detector/DetFCCeeCLD/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(DetFCCeeCLD DD4hep::DDCore)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 add_test(NAME ConstructDetFCCeeCLD
-         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCCeeCLD/compact/FCCee_o2_v02/FCCee_o2_v02.xml\", \"fccee_cld.root\")"
+         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCCeeCLD/compact/FCCee_o2_v02/FCCee_o2_v02.xml\", \"${CMAKE_BINARY_DIR}/fccee_cld.root\")"
          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
          )
 k4_set_test_env(ConstructDetFCCeeCLD)

--- a/Detector/DetFCCeeIDEA-LAr/CMakeLists.txt
+++ b/Detector/DetFCCeeIDEA-LAr/CMakeLists.txt
@@ -5,7 +5,7 @@
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/compact DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/Detector/DetFCCeeIDEA-LAr)
 
 add_test(NAME ConstructDetFFCCeeIDEALAr
-         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml\", \"fccee_nlq.root\")"
+         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml\", \"${CMAKE_BINARY_DIR}/fccee_nlq.root\")"
          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
          )
 k4_set_test_env(ConstructDetFFCCeeIDEALAr)

--- a/Detector/DetFCCeeIDEA/CMakeLists.txt
+++ b/Detector/DetFCCeeIDEA/CMakeLists.txt
@@ -13,7 +13,7 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 
 add_test(NAME ConstructDetFFCCeeIDEA
-         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCCeeIDEA/compact/FCCee_DectMaster.xml\", \"fccee_idea.root\")"
+         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCCeeIDEA/compact/FCCee_DectMaster.xml\", \"${CMAKE_BINARY_DIR}/fccee_idea.root\")"
          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
          )
 k4_set_test_env(ConstructDetFFCCeeIDEA)

--- a/Detector/DetFCChhBaseline1/CMakeLists.txt
+++ b/Detector/DetFCChhBaseline1/CMakeLists.txt
@@ -8,7 +8,7 @@ install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/compact DESTINATION ${CMAKE_INSTALL_
 
 
 add_test(NAME ConstructDetFCChhBaseline1
-         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml\", \"fcchh_baseline.root\")"
+         COMMAND root -q -b ".github/scripts/load_detector.C(\"Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml\", \"${CMAKE_BINARY_DIR}/fcchh_baseline.root\")"
          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
          )
 k4_set_test_env(ConstructDetFCChhBaseline1)


### PR DESCRIPTION
Saving test output to the build directory so they don't clutter main project directory.