### PR TITLE
[DriftChamber] Fix segfault due to wrong material implementation

### DIFF
--- a/Detector/DetFCCeeIDEA/compact/DriftChamber_materials.xml
+++ b/Detector/DetFCCeeIDEA/compact/DriftChamber_materials.xml
@@ -306,6 +306,7 @@
       <MEE unit="eV" value="166"/>
       <D unit="g/cm3" value="2.699"/>
       <atom unit="g/mole" value="26.9815"/>
+      <fraction n="1.0" ref="Al0x5633439c3890"/>
     </material>
     <material name="Kapton" state="solid">
       <T unit="K" value="293.15"/>
@@ -328,6 +329,7 @@
       <MEE unit="eV" value="790"/>
       <D unit="g/cm3" value="19.32"/>
       <atom unit="g/mole" value="196.967"/>
+      <fraction n="1.0" ref="Au"/>
     </material>
     <isotope N="180" Z="74" name="W1800x563354403a30">
       <atom unit="g/mole" value="179.947"/>


### PR DESCRIPTION
This problem was probably not spotted because it only appears when DD4hep tries to translate the geometry from TGeo to Geant4, which is not done when using only geoDisplay.

A check for this could probably be added in DD4hep [dd4hep::sim::Geant4Converter::handleMaterial](https://github.com/AIDASoft/DD4hep/blob/master/DDG4/src/Geant4Converter.cpp#L313) to avoid hitting a segfault and ease debugging.