### PR TITLE
Implement module-theta readout (with per-layer merging)

### DIFF
--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -100,7 +100,7 @@
 
     <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
     <readout name="ECalBarrelModuleThetaMerged2">
-        <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 8 2 1 8 4 2 1 4 2 1 8" mergedModules="2 2 2 2 2 2 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+        <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -81,10 +81,10 @@
     <!-- readout for the simulation -->
     <!-- offset in theta is the eta max value including cryostat TO BE FIXED -->
     <!-- THIS LACKS Z POSITION -->
-    <readout name="ECalBarrelTheta">
-        <segmentation type="GridTheta" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+    <!--readout name="ECalBarrelTheta">
+        <segmentation type="GridTheta" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
-    </readout>
+    </readout-->
 
     <!-- readout for the reconstruction, with phi-theta -->
     <!-- readout name="ECalBarrelPhiTheta">
@@ -92,15 +92,17 @@
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,phi:11,theta:10</id>
     </readout -->
 
-    <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
+    <!-- readout for the simulation, with no merged modules and no merged cells in theta -->
     <readout name="ECalBarrelModuleThetaMerged">
-        <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="1 1 1 1 1 1 1 1 1 1 1 1" mergedModules="1 1 1 1 1 1 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+      <!--segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="1 1 1 1 1 1 1 1 1 1 1 1" mergedModules="1 1 1 1 1 1 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/-->
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
 
     <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
     <readout name="ECalBarrelModuleThetaMerged2">
-        <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/>
+        <!--segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/-->
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -79,38 +79,21 @@
   </display>
 
   <readouts>
-    <!-- readout for the simulation -->
-    <!-- offset in theta is the eta max value including cryostat TO BE FIXED -->
-    <!-- THIS LACKS Z POSITION -->
-    <!--readout name="ECalBarrelTheta">
-        <segmentation type="GridTheta" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
-        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
-    </readout-->
-
-    <!-- readout for the reconstruction, with phi-theta -->
-    <!-- readout name="ECalBarrelPhiTheta">
-        <segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.009817477/4" phi_bins="1545" offset_theta="0.58902785" offset_phi="-pi+(pi/1545.)"/>
-        <id>system:4,cryo:1,type:3,subtype:3,layer:8,phi:11,theta:10</id>
-    </readout -->
-
-    <!-- readout for the simulation, with no merged modules and no merged cells in theta -->
+    <!-- readout for the simulation, with the baseline merging: 2x along the module direction in each layer; 4x along theta in each layer except layer 1 -->
+    <!-- the lists mergedCells_Theta and mergedModules define the number of cells to group together in the theta and module direction as a function of the layer -->
     <readout name="ECalBarrelModuleThetaMerged">
-      <!--segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="1 1 1 1 1 1 1 1 1 1 1 1" mergedModules="1 1 1 1 1 1 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/-->
       <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
 
-    <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
+    <!-- example of adding a second readout for the reconstruction, to compare the two -->
     <readout name="ECalBarrelModuleThetaMerged2">
       <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
-        <!--segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/-->
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>
 
   <detectors>
-    <!--detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelEta"-->
-    <!-- detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelTheta"-->
     <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelModuleThetaMerged">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
       <sensitive type="SimpleCalorimeterSD"/>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -94,13 +94,13 @@
 
     <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
     <readout name="ECalBarrelModuleThetaMerged">
-        <segmentation type="FCCSWGridModuleThetaMerged" mergedCells_Theta="1 1 1 1 1 1 1 1 1 1 1 1" mergedModules="1 1 1 1 1 1 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+        <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="1 1 1 1 1 1 1 1 1 1 1 1" mergedModules="1 1 1 1 1 1 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
 
     <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
     <readout name="ECalBarrelModuleThetaMerged2">
-        <segmentation type="FCCSWGridModuleThetaMerged" mergedCells_Theta="4 8 2 1 8 4 2 1 4 2 1 8" mergedModules="2 2 2 2 2 2 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+        <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 8 2 1 8 4 2 1 4 2 1 8" mergedModules="2 2 2 2 2 2 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -58,6 +58,7 @@
     <!-- When employing trapezoidal planes Pb_thickness corresponds to the minimum thickness, i.e at the front of the calo -->
     <constant name="Pb_thickness" value="1.80*mm"/>
     <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
+    <constant name="ECalBarrelNumPlanes" value="1545"/>
     <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
     <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
     <!-- approximate constant sampling fraction: make the absorber grow linearly with the radius,

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -82,27 +82,27 @@
     <!-- offset in theta is the eta max value including cryostat TO BE FIXED -->
     <!-- THIS LACKS Z POSITION -->
     <!--readout name="ECalBarrelTheta">
-        <segmentation type="GridTheta" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/>
+        <segmentation type="GridTheta" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout-->
 
     <!-- readout for the reconstruction, with phi-theta -->
     <!-- readout name="ECalBarrelPhiTheta">
-        <segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.00981745/4" phi_bins="1545" offset_theta="0.589049" offset_phi="-pi+(pi/1545.)"/>
+        <segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.009817477/4" phi_bins="1545" offset_theta="0.58902785" offset_phi="-pi+(pi/1545.)"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,phi:11,theta:10</id>
     </readout -->
 
     <!-- readout for the simulation, with no merged modules and no merged cells in theta -->
     <readout name="ECalBarrelModuleThetaMerged">
       <!--segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="1 1 1 1 1 1 1 1 1 1 1 1" mergedModules="1 1 1 1 1 1 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/-->
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
 
     <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
     <readout name="ECalBarrelModuleThetaMerged2">
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/>
-        <!--segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.00981745/4" offset_theta="0.5902785"/-->
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+        <!--segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/-->
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -59,6 +59,7 @@
     <constant name="Pb_thickness" value="1.80*mm"/>
     <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
     <constant name="ECalBarrelNumPlanes" value="1545"/>
+    <constant name="ECalBarrelNumLayers" value="12"/>
     <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
     <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
     <!-- approximate constant sampling fraction: make the absorber grow linearly with the radius,

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="FCCee_ECalBarrel"
+        title="Settings for FCCee Inclined ECal Barrel Calorimeter"
+        author="M.Aleksa,J.Faltova,A.Zaborowska, V. Volkl"
+        url="no"
+        status="development"
+        version="1.0">
+    <comment>
+      Settings for the inclined EM calorimeter.
+      The barrel is filled with liquid argon. Passive material includes lead in the middle and steal on the outside, glued together.
+      Passive plates are inclined by a certain angle from the radial direction.
+      In between of two passive plates there is a readout.
+      Space between the plate and readout is of trapezoidal shape and filled with liquid argon.
+      Definition of sizes, visualization settings, readout and longitudinal segmentation are specified. 
+    </comment>
+  </info>
+
+  <define>
+    <!-- Inclination angle of the lead plates -->
+    <constant name="InclinationAngle" value="50*degree"/>
+    <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
+    <constant name="LArGapThickness" value="1.239749*2*mm"/>
+
+    <!-- Air margin, thicknesses of cryostat and LAr bath -->
+    <constant name="AirMarginThickness" value="54*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
+
+    <constant name="CryoBarrelFrontWarm" value="10*mm"/>   <!-- Al solid corresponding to 0.11 X0 -->
+    <constant name="CryoBarrelFrontCold" value="3.8*mm"/>  <!-- Al solid equivalent of 0.043 X0 sandwich CFRP -->
+    <constant name="CryoBarrelFront" value="CryoBarrelFrontWarm+CryoBarrelFrontCold"/>
+
+    <constant name="CryoBarrelBackCold" value="30*mm"/>   <!-- Al solid corresponding to 0.34 X0 -->
+    <constant name="CryoBarrelBackWarm" value="2.7*mm"/>  <!-- Al solid equivalent of 0.03 X0 sandwich CFRP -->
+    <constant name="SolenoidBarrel" value="70*mm"/>    <!-- Al solenoid with thickness of 0.8 X0 -->
+    <constant name="CryoBarrelBack" value="CryoBarrelBackWarm+SolenoidBarrel+CryoBarrelBackCold"/>
+
+    <constant name="CryoBarrelSideWarm" value="30*mm"/>
+    <constant name="CryoBarrelSideCold" value="3.8*mm"/>
+    <constant name="CryoBarrelSide" value="CryoBarrelSideWarm+CryoBarrelSideCold"/>
+
+    <constant name="LArBathThicknessFront" value="5*mm"/>
+    <constant name="LArBathThicknessBack" value="40*mm"/>
+
+    <!-- air margin around calorimeter -->
+    <constant name="BarCryoECal_rmin" value="BarECal_rmin+AirMarginThickness"/>
+    <constant name="BarCryoECal_rmax" value="BarECal_rmax-AirMarginThickness"/>
+    <constant name="BarCryoECal_dz" value="BarECal_dz"/>
+    <!-- calorimeter active volume -->
+    <constant name="EMBarrel_rmin" value="BarCryoECal_rmin+CryoBarrelFront+LArBathThicknessFront"/>
+    <constant name="EMBarrel_rmax" value="BarCryoECal_rmax-CryoBarrelBack-LArBathThicknessBack"/>
+    <constant name="EMBarrel_dz" value="BarECal_dz-CryoBarrelSide"/>
+    <!-- thickness of active volume between two absorber plates at EMBarrel_rmin, measuring perpendicular to the readout plate -->
+    <constant name="LAr_thickness" value="LArGapThickness"/>
+    <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
+    <!-- When employing trapezoidal planes Pb_thickness corresponds to the minimum thickness, i.e at the front of the calo -->
+    <constant name="Pb_thickness" value="1.80*mm"/>
+    <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
+    <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
+    <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
+    <!-- approximate constant sampling fraction: make the absorber grow linearly with the radius,
+         taking into account the angular projection effect -->
+    <!-- <constant name="Pb_thickness_max" value="1.3 * Pb_thickness * EMBarrel_rmax/EMBarrel_rmin *
+         cos(InclinationAngle - phi) / cos(InclinationAngle)" />-->
+    <constant name="Pb_thickness_max" value="Pb_thickness" />
+    <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Steel_thickness" value="0.1*mm"/>
+    <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Glue_thickness" value="0.1*mm"/>
+    <!-- readout in between two absorber plates -->
+    <constant name="readout_thickness" value="1.2*mm"/>
+  </define>
+
+  <display>
+    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true" />
+  </display>
+
+  <readouts>
+    <!-- readout for the simulation -->
+    <!-- offset in theta is the eta max value including cryostat TO BE FIXED -->
+    <!-- THIS LACKS Z POSITION -->
+    <readout name="ECalBarrelTheta">
+        <segmentation type="GridTheta" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
+    </readout>
+
+    <!-- readout for the reconstruction, with phi-theta -->
+    <!-- readout name="ECalBarrelPhiTheta">
+        <segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.00981745/4" phi_bins="1545" offset_theta="0.589049" offset_phi="-pi+(pi/1545.)"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,phi:11,theta:10</id>
+    </readout -->
+
+    <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
+    <readout name="ECalBarrelModuleThetaMerged">
+        <segmentation type="FCCSWGridModuleThetaMerged" mergedCells_Theta="1 1 1 1 1 1 1 1 1 1 1 1" mergedModules="1 1 1 1 1 1 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
+    </readout>
+
+    <!-- readout for the reconstruction, with merged modules and merged cells in theta -->
+    <readout name="ECalBarrelModuleThetaMerged2">
+        <segmentation type="FCCSWGridModuleThetaMerged" mergedCells_Theta="4 8 2 1 8 4 2 1 4 2 1 8" mergedModules="2 2 2 2 2 2 1 1 1 1 1 1" grid_size_theta="0.00981745/4" offset_theta="0.589049"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
+    </readout>
+  </readouts>
+
+  <detectors>
+    <!--detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelEta"-->
+    <!-- detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelTheta"-->
+    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelModuleThetaMerged">
+      <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
+      <sensitive type="SimpleCalorimeterSD"/>
+      <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
+      <cryostat name="ECAL_Cryo">
+        <material name="Aluminum"/>
+	<dimensions rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoBarrelFront" rmax1="BarCryoECal_rmax-CryoBarrelBack" rmax2="BarCryoECal_rmax" dz="BarCryoECal_dz"/>
+        <front sensitive="false"/> <!-- inner wall of the cryostat -->
+        <side sensitive="false"/> <!-- both sides of the cryostat -->
+        <back sensitive="false"/> <!-- outer wall of the cryostat -->
+      </cryostat>
+      <calorimeter name="EM_barrel">
+        <!-- offset defines the numbering of the modules: module==0 for phi=0 direction -->
+        <dimensions rmin="EMBarrel_rmin" rmax="EMBarrel_rmax" dz="EMBarrel_dz" offset="-InclinationAngle"/>
+        <active thickness="LAr_thickness">
+          <material name="LAr"/>
+          <!-- overlap offset is a specific feature of the construction; do not change! -->
+          <!-- one volume for a gap on both side of the readout) --> 
+          <overlap offset="0.5"/>
+        </active>
+        <passive>
+          <rotation angle="InclinationAngle"/>  <!-- inclination angle -->
+          <inner thickness="Pb_thickness" sensitive="false">
+            <material name="Lead"/>
+          </inner>
+          <innerMax thickness="Pb_thickness_max" sensitive="false">
+            <material name="Lead"/>
+          </innerMax>
+          <glue thickness="Glue_thickness" sensitive="false">
+            <material name="lArCaloGlue"/>
+          </glue>
+          <outer thickness="Steel_thickness" sensitive="false">
+            <material name="lArCaloSteel"/>
+          </outer>
+        </passive>
+        <readout thickness="readout_thickness" sensitive="false">
+          <material name="PCB"/>
+        </readout>
+        <layers> <!-- pcb electrode segmentation in the radial direction -->
+           <layer thickness="1.5*cm" repeat="1"/>
+           <layer thickness="3.5*cm" repeat="11"/>
+        </layers>
+      </calorimeter>
+    </detector>
+  </detectors>
+</lccdd>

--- a/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster_thetamodulemerged.xml
+++ b/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster_thetamodulemerged.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="FCCee-IDEA-LAr Master"
+    title="FCCee-IDEA-LAr Master"
+    author="Valentin Volkl"
+    url="no"
+    status="development"
+    version="1.0">
+    <comment>
+      Master compact file describing the latest developments of the FCCee IDEA detector concept with a LAr calorimeter.
+    </comment>
+  </info>
+
+  <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml" />
+
+  <includes>
+    <gdmlFile  ref="../../DetCommon/compact/elements.xml"/>
+    <gdmlFile  ref="../../DetCommon/compact/materials.xml"/>
+  </includes>
+
+  <define>
+    <constant name="world_size" value="25*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+  </define>
+
+  <include ref="./FCCee_DectDimensions.xml" />
+
+  <include ref="../../DetFCCeeIDEA/compact/Beampipe.xml"/>
+  <include ref="../../DetFCCeeIDEA/compact/BeamInstrumentation.xml"/>
+  <include ref="../../DetFCCeeIDEA/compact/LumiCal.xml"/>
+  <include ref="../../DetFCCeeIDEA/compact/HOMAbsorber.xml"/> 
+  <include ref="../../DetFCCeeCLD/compact/FCCee_o2_v02/Vertex.xml"/>
+  <include ref="../../DetFCCeeIDEA/compact/SimplifiedDriftChamber.xml"/>
+  <include ref="../../DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml"/>
+  <include ref="../../DetFCCeeHCalTile/compact/FCCee_HCalBarrel_TileCal.xml"/>
+  <include ref="../../DetFCCeeCalDiscs/compact/FCCee_EcalEndcaps_coneCryo.xml"/>
+  <include ref="../../DetFCCeeHCalTile/compact/FCCee_HCalEndcaps_ThreeParts_TileCal.xml"/>
+  <include ref="MuonTagger.xml"/>
+
+</lccdd>

--- a/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
+++ b/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
@@ -185,12 +185,21 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
        << " rotation angle = " << angle << endmsg;
   uint numPlanes =
       round(M_PI / asin((passiveThickness + activeThickness + readoutThickness) / (2. * caloDim.rmin() * cos(angle))));
-  /*
-  const std::string strNumPlanes = std::to_string(numPlanes);
-  dd4hep::_toDictionary("ECalBarrelNumPlanes", strNumPlanes, "number");
-  dd4hep::Constant constNumPlanes("ECalBarrelNumPlanes", strNumPlanes, "number");
-  aLcdd.addConstant(constNumPlanes);
-  */
+
+  int nModules = -1;
+  try {
+    nModules = aLcdd.constant<int>("ECalBarrelNumPlanes");
+  }
+  catch(...) {
+    ;
+  }
+  if (nModules > 0 && nModules != numPlanes) {
+    lLog << MSG::ERROR << "Incorrect number of planes in xml file!" << endmsg;
+    // todo: incidentSvc->fireIncident(Incident("ECalConstruction", "GeometryFailure"));
+    // make the code crash (incidentSvc does not work)
+     assert(nModules == numPlanes);
+  }
+  //std::cout << "Number of modules read from detector metadata and used in readout class: " << m_nModules << std::endl;
   double dPhi = 2. * M_PI / numPlanes;
   lLog << MSG::INFO << "number of passive plates = " << numPlanes << " azim. angle difference =  " << dPhi << endmsg;
   lLog << MSG::INFO << " distance at inner radius (cm) = " << 2. * M_PI * caloDim.rmin() / numPlanes << "\n"

--- a/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
+++ b/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
@@ -185,6 +185,12 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
        << " rotation angle = " << angle << endmsg;
   uint numPlanes =
       round(M_PI / asin((passiveThickness + activeThickness + readoutThickness) / (2. * caloDim.rmin() * cos(angle))));
+  /*
+  const std::string strNumPlanes = std::to_string(numPlanes);
+  dd4hep::_toDictionary("ECalBarrelNumPlanes", strNumPlanes, "number");
+  dd4hep::Constant constNumPlanes("ECalBarrelNumPlanes", strNumPlanes, "number");
+  aLcdd.addConstant(constNumPlanes);
+  */
   double dPhi = 2. * M_PI / numPlanes;
   lLog << MSG::INFO << "number of passive plates = " << numPlanes << " azim. angle difference =  " << dPhi << endmsg;
   lLog << MSG::INFO << " distance at inner radius (cm) = " << 2. * M_PI * caloDim.rmin() / numPlanes << "\n"

--- a/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
+++ b/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
@@ -186,6 +186,15 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
   uint numPlanes =
       round(M_PI / asin((passiveThickness + activeThickness + readoutThickness) / (2. * caloDim.rmin() * cos(angle))));
 
+  // The following code checks if the xml geometry file contains a constant defining
+  // the number of planes in the barrel. In that case, it makes the program abort
+  // if the number of planes in the xml is different from the one calculated from
+  // the geometry. This is because the number of plane information (retrieved from the
+  // xml) is used in other parts of the code (the readout for the FCC-ee ECAL with
+  // inclined modules). In principle the code above should be refactored so that the number
+  // of planes is one of the inputs of the calculation and other geometrical parameters
+  // are adjusted accordingly. This is left for the future, and we use the workaround
+  // below to enforce for the time being that the number of planes is "correct"
   int nModules = -1;
   try {
     nModules = aLcdd.constant<int>("ECalBarrelNumPlanes");
@@ -199,7 +208,6 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
     // make the code crash (incidentSvc does not work)
      assert(nModules == numPlanes);
   }
-  //std::cout << "Number of modules read from detector metadata and used in readout class: " << m_nModules << std::endl;
   double dPhi = 2. * M_PI / numPlanes;
   lLog << MSG::INFO << "number of passive plates = " << numPlanes << " azim. angle difference =  " << dPhi << endmsg;
   lLog << MSG::INFO << " distance at inner radius (cm) = " << 2. * M_PI * caloDim.rmin() / numPlanes << "\n"

--- a/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
+++ b/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
@@ -66,6 +66,25 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
     layersTotalHeight += layer.repeat() * layer.thickness();
   }
   lLog << MSG::DEBUG << "Number of layers: " << numLayers << " total thickness " << layersTotalHeight << endmsg;
+  // The following code checks if the xml geometry file contains a constant defining
+  // the number of layers the barrel. In that case, it makes the program abort
+  // if the number of planes in the xml is different from the one calculated from
+  // the geometry. This is because the number of layers is needed
+  // in other parts of the code (the readout for the FCC-ee ECAL with
+  // inclined modules).
+  int nLayers = -1;
+  try {
+    nLayers = aLcdd.constant<int>("ECalBarrelNumLayers");
+  }
+  catch(...) {
+    ;
+  }
+  if (nLayers > 0 && nLayers != numLayers) {
+    lLog << MSG::ERROR << "Incorrect number of layers (ECalBarrelNumLayers) in xml file!" << endmsg;
+    // todo: incidentSvc->fireIncident(Incident("ECalConstruction", "GeometryFailure"));
+    // make the code crash (incidentSvc does not work)
+     assert(nLayers == numLayers);
+  }
 
   dd4hep::xml::DetElement readout = calo.child(_Unicode(readout));
   std::string readoutMaterial = readout.materialStr();
@@ -203,7 +222,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
     ;
   }
   if (nModules > 0 && nModules != numPlanes) {
-    lLog << MSG::ERROR << "Incorrect number of planes in xml file!" << endmsg;
+    lLog << MSG::ERROR << "Incorrect number of planes (ECalBarrelNumPlanes) in xml file!" << endmsg;
     // todo: incidentSvc->fireIncident(Incident("ECalConstruction", "GeometryFailure"));
     // make the code crash (incidentSvc does not work)
      assert(nModules == numPlanes);

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -69,7 +69,7 @@ public:
   /**  Set the number of modules
    *   return The number of modules (as it was set by the user in the xml file..)
    */
-  inline int setNModules(const int nModules) { m_nModules = nModules; }
+  inline void setNModules(const int nModules) { m_nModules = nModules; }
   /**  Get the field name used for the layer
    *   return The field name for the layer.
    */

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -1,0 +1,103 @@
+#ifndef DETSEGMENTATION_FCCSWGRIDMODULETHETAMERGED_H
+#define DETSEGMENTATION_FCCSWGRIDMODULETHETAMERGED_H
+
+// FCCSW
+#include "DetSegmentation/GridTheta.h"
+#include "DD4hep/VolumeManager.h"
+
+/** FCCSWGridModuleThetaMerged Detector/DetSegmentation/DetSegmentation/FCCSWGridModuleThetaMerged.h FCCSWGridModuleThetaMerged.h
+ *
+ *  Segmentation in theta and module.
+ *  Based on GridTheta, merges modules and theta cells based on layer number
+ *
+ */
+
+namespace dd4hep {
+namespace DDSegmentation {
+class FCCSWGridModuleThetaMerged : public GridTheta {
+public:
+  /// default constructor using an arbitrary type
+  FCCSWGridModuleThetaMerged(const std::string& aCellEncoding);
+  /// Default constructor used by derived classes passing an existing decoder
+  FCCSWGridModuleThetaMerged(const BitFieldCoder* decoder);
+
+  /// destructor
+  virtual ~FCCSWGridModuleThetaMerged() = default;
+
+  /**  Determine the local position based on the cell ID.
+   *   @param[in] aCellId ID of a cell.
+   *   return Position (relative to R, phi of Geant4 volume it belongs to, scaled for R=1).
+   */
+  virtual Vector3D position(const CellID& aCellID) const;
+  /**  Determine the cell ID based on the position.
+   *   @param[in] aLocalPosition (not used).
+   *   @param[in] aGlobalPosition
+   *   @param[in] aVolumeId ID of the Geant4 volume
+   *   return Cell ID.
+   */
+  virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
+                        const VolumeID& aVolumeID) const;
+  /**  Determine the azimuthal angle (relative to the G4 volume) based on the cell ID.
+   *   @param[in] aCellId ID of a cell.
+   *   return Phi.
+   */
+  double phi(const CellID& aCellID) const;
+  /**  Determine the polar angle (relative to the G4 volume) based on the cell ID.
+   *   @param[in] aCellId ID of a cell.
+   *   return Theta.
+   */
+  double theta(const CellID& aCellID) const;
+  /**  Determine the radius based on the cell ID.
+   *   @param[in] aCellId ID of a cell.
+   *   return Radius.
+   */
+  // double radius(const CellID& aCellID) const;
+  /**  Get the number of merged cells in theta for given layer
+   *   @param[in] layer
+   *   return The number of merged cells in theta
+   */
+  inline int mergedThetaCells(const unsigned int layer) const { return m_mergedCellsTheta[layer]; }
+  /**  Get the number of merged modules (inclined in phi)
+   *   @param[in] layer
+   *   return The number of merged cells in theta
+   */
+  inline int mergedModules(const unsigned int layer) const { return m_mergedModules[layer]; }
+  /**  Get the number of modules
+   *   return The number of modules (as it was set by the user in the xml file..)
+   */
+  inline int nModules() const { return m_nModules; }
+  /**  Set the number of modules
+   *   return The number of modules (as it was set by the user in the xml file..)
+   */
+  inline int setNModules(const int nModules) { m_nModules = nModules; }
+  /**  Get the field name used for the layer
+   *   return The field name for the layer.
+   */
+  inline const std::string& fieldNameLayer() const { return m_layerID; }
+  /**  Get the field name used for the module number
+   *   return The field name for the module.
+   */
+  inline const std::string& fieldNameModule() const { return m_moduleID; }
+
+protected:
+  /// the field name used for layer
+  std::string m_layerID;
+  /// the field name used for the read-out module (can differ from module due to merging)
+  std::string m_moduleID;
+  /// vector of number of cells to be merged along theta for each layer
+  std::vector<int> m_mergedCellsTheta;
+  /// vector of number of modules to be merged for each layer
+  std::vector<int> m_mergedModules;
+
+  /// to be seen if we need these
+  /// and how to retrieve them at initialization step from the geometry
+  /// number of modules (or, equivalently, the deltaPhi between adjacent modules)
+  int m_nModules;
+  /// innermost radius of electrodes (not needed)
+  /// std::vector<double> m_rLayers;
+  /// inclination in phi of electrodes (not needed)
+  //// double m_alpha;
+};
+}
+}
+#endif /* DETSEGMENTATION_FCCSWGRIDMODULETHETAMERGED_H */

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -56,12 +56,12 @@ public:
    *   @param[in] layer
    *   return The number of merged cells in theta
    */
-  inline int mergedThetaCells(const unsigned int layer) const { return m_mergedCellsTheta[layer]; }
+  inline int mergedThetaCells(const int layer) const { return m_mergedCellsTheta[layer]; }
   /**  Get the number of merged modules (inclined in phi)
    *   @param[in] layer
    *   return The number of merged cells in theta
    */
-  inline int mergedModules(const unsigned int layer) const { return m_mergedModules[layer]; }
+  inline int mergedModules(const int layer) const { return m_mergedModules[layer]; }
   /**  Get the number of modules
    *   return The number of modules (as it was set by the user in the xml file..)
    */

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -24,6 +24,9 @@ public:
   /// destructor
   virtual ~FCCSWGridModuleThetaMerged() = default;
 
+  /// read nmodules from detector metadata
+  void GetNModulesFromGeom();
+  
   /**  Determine the local position based on the cell ID.
    *   @param[in] aCellId ID of a cell.
    *   return Position (relative to R, phi of Geant4 volume it belongs to, scaled for R=1).

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -89,14 +89,9 @@ protected:
   /// vector of number of modules to be merged for each layer
   std::vector<int> m_mergedModules;
 
-  /// to be seen if we need these
-  /// and how to retrieve them at initialization step from the geometry
+  /// to be seen how to retrieve this initialization step from the geometry
   /// number of modules (or, equivalently, the deltaPhi between adjacent modules)
   int m_nModules;
-  /// innermost radius of electrodes (not needed)
-  /// std::vector<double> m_rLayers;
-  /// inclination in phi of electrodes (not needed)
-  //// double m_alpha;
 };
 }
 }

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -24,8 +24,11 @@ public:
   /// destructor
   virtual ~FCCSWGridModuleThetaMerged() = default;
 
-  /// read nmodules from detector metadata
+  /// read n(modules) from detector metadata
   void GetNModulesFromGeom();
+
+  /// read n(layers) from detector metadata
+  void GetNLayersFromGeom();
   
   /**  Determine the local position based on the cell ID.
    *   @param[in] aCellId ID of a cell.
@@ -59,20 +62,30 @@ public:
    *   @param[in] layer
    *   return The number of merged cells in theta
    */
-  inline int mergedThetaCells(const int layer) const { return m_mergedCellsTheta[layer]; }
+  inline int mergedThetaCells(const int layer) const {
+    if (layer<m_mergedCellsTheta.size())
+      return m_mergedCellsTheta[layer];
+    else
+      return 1;
+  }
   /**  Get the number of merged modules (inclined in phi)
    *   @param[in] layer
-   *   return The number of merged cells in theta
+   *   return The number of merged modules
    */
-  inline int mergedModules(const int layer) const { return m_mergedModules[layer]; }
-  /**  Get the number of modules
+  inline int mergedModules(const int layer) const {
+    if (layer<m_mergedModules.size())
+      return m_mergedModules[layer];
+    else
+      return 1;
+  }
+  /**  Get the total number of modules of detector
    *   return The number of modules (as it was set by the user in the xml file..)
    */
   inline int nModules() const { return m_nModules; }
-  /**  Set the number of modules
-   *   return The number of modules (as it was set by the user in the xml file..)
+  /**  Get the number of layers
+   *   return The number of layers
    */
-  inline void setNModules(const int nModules) { m_nModules = nModules; }
+  inline int nLayers() const { return m_nLayers; }
   /**  Get the field name used for the layer
    *   return The field name for the layer.
    */
@@ -92,9 +105,12 @@ protected:
   /// vector of number of modules to be merged for each layer
   std::vector<int> m_mergedModules;
 
-  /// to be seen how to retrieve this initialization step from the geometry
   /// number of modules (or, equivalently, the deltaPhi between adjacent modules)
   int m_nModules;
+
+  /// number of layers (from the geometry)
+  int m_nLayers;
+  
 };
 }
 }

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMergedHandle.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMergedHandle.h
@@ -1,0 +1,127 @@
+#ifndef DD4HEP_DDCORE_GRIDMODULETHETAMERGED_H
+#define DD4HEP_DDCORE_GRIDMODULETHETAMERGED_H 1
+
+// FCCSW
+#include "DetSegmentation/FCCSWGridModuleThetaMerged.h"
+
+// DD4hep
+#include "DD4hep/Segmentations.h"
+#include "DD4hep/detail/SegmentationsInterna.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+/// Namespace for base segmentations
+
+
+// Forward declarations
+class Segmentation;
+template <typename T>
+class SegmentationWrapper;
+
+/// We need some abbreviation to make the code more readable.
+typedef Handle<SegmentationWrapper<DDSegmentation::FCCSWGridModuleThetaMerged>> FCCSWGridModuleThetaMergedHandle;
+
+/// Implementation class for the module-theta (with per-layer merging) segmentation.
+/**
+ *  Concrete user handle to serve specific needs of client code
+ *  which requires access to the base functionality not served
+ *  by the super-class Segmentation.
+ *
+ *  Note:
+ *  We only check the validity of the underlying handle.
+ *  If for whatever reason the implementation object is not valid
+ *  This is not checked.
+ *  In principle this CANNOT happen unless some brain-dead has
+ *  fiddled with the handled object directly.....
+ *
+ *  Note:
+ *  The handle base corrsponding to this object in for
+ *  conveniance reasons instantiated in DD4hep/src/Segmentations.cpp.
+ *
+ */
+class FCCSWGridModuleThetaMerged : public FCCSWGridModuleThetaMergedHandle {
+public:
+  /// Definition of the basic handled object
+  typedef FCCSWGridModuleThetaMergedHandle::Object Object;
+
+public:
+  /// Default constructor
+  FCCSWGridModuleThetaMerged() = default;
+  /// Copy constructor
+  FCCSWGridModuleThetaMerged(const FCCSWGridModuleThetaMerged& e) = default;
+  /// Copy Constructor from segmentation base object
+  FCCSWGridModuleThetaMerged(const Segmentation& e) : Handle<Object>(e) {}
+  /// Copy constructor from handle
+  FCCSWGridModuleThetaMerged(const Handle<Object>& e) : Handle<Object>(e) {}
+  /// Copy constructor from other polymorph/equivalent handle
+  template <typename Q>
+  FCCSWGridModuleThetaMerged(const Handle<Q>& e) : Handle<Object>(e) {}
+  /// Assignment operator
+  FCCSWGridModuleThetaMerged& operator=(const FCCSWGridModuleThetaMerged& seg) = default;
+  /// Equality operator
+  bool operator==(const FCCSWGridModuleThetaMerged& seg) const { return m_element == seg.m_element; }
+
+  /// determine the position based on the cell ID
+  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+
+  /// determine the cell ID based on the position
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+    return access()->implementation->cellID(local, global, volID);
+  }
+
+
+  /// access the grid size in theta
+  inline double gridSizeTheta() const { return access()->implementation->gridSizeTheta(); }
+
+  /// access the coordinate offset in theta
+  inline double offsetTheta() const { return access()->implementation->offsetTheta(); }
+
+  /// access the number of theta cells merged for given layer
+  inline int mergedThetaCells(const unsigned int layer) const { return access()->implementation->mergedThetaCells(layer); }
+
+  /// access the number of modules
+  inline int nModules() const { return access()->implementation->nModules(); }
+
+  /// access the number of merged modules for given layer
+  inline int mergedModules(const unsigned int layer) const { return access()->implementation->mergedModules(layer); }
+
+
+  /// set the coordinate offset in theta
+  inline void setOffsetTheta(double offset) const { access()->implementation->setOffsetTheta(offset); }
+
+  /// set the grid size in theta
+  inline void setGridSizeTheta(double cellSize) const { access()->implementation->setGridSizeTheta(cellSize); }
+
+  /// set the number of modules
+  inline void setNModules(int nModules) const { access()->implementation->setNModules(nModules); }
+
+
+  /// access the field name used for theta
+  inline const std::string& fieldNameTheta() const { return access()->implementation->fieldNameTheta(); }
+
+  /// access the field name used for module
+  inline const std::string& fieldNameModule() const { return access()->implementation->fieldNameModule(); }
+
+  /// access the field name used for layer
+  inline const std::string& fieldNameLayer() const { return access()->implementation->fieldNameLayer(); }
+
+
+  /** \brief Returns a std::vector<double> of the cellDimensions of the given cell ID
+      in natural order of dimensions (dPhi, dTheta)
+
+      Returns a std::vector of the cellDimensions of the given cell ID
+      \param cellID is ignored as all cells have the same dimension
+      \return std::vector<double> size 2:
+      -# size in phi
+      -# size in theta
+  */
+  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+    //return {access()->implementation->gridSizePhi(), access()->implementation->gridSizeTheta()};
+    // not implemented
+    return {0., 0.};
+  }
+};
+
+} /* End namespace dd4hep                */
+#endif  // DD4HEP_DDCORE_GRIDMODULETHETAMERGED_H

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMergedHandle.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMergedHandle.h
@@ -78,13 +78,13 @@ public:
   inline double offsetTheta() const { return access()->implementation->offsetTheta(); }
 
   /// access the number of theta cells merged for given layer
-  inline int mergedThetaCells(const unsigned int layer) const { return access()->implementation->mergedThetaCells(layer); }
+  inline int mergedThetaCells(const int layer) const { return access()->implementation->mergedThetaCells(layer); }
 
   /// access the number of modules
   inline int nModules() const { return access()->implementation->nModules(); }
 
   /// access the number of merged modules for given layer
-  inline int mergedModules(const unsigned int layer) const { return access()->implementation->mergedModules(layer); }
+  inline int mergedModules(const int layer) const { return access()->implementation->mergedModules(layer); }
 
 
   /// set the coordinate offset in theta

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMergedHandle.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMergedHandle.h
@@ -70,7 +70,6 @@ public:
     return access()->implementation->cellID(local, global, volID);
   }
 
-
   /// access the grid size in theta
   inline double gridSizeTheta() const { return access()->implementation->gridSizeTheta(); }
 
@@ -83,19 +82,17 @@ public:
   /// access the number of modules
   inline int nModules() const { return access()->implementation->nModules(); }
 
+  /// access the number of layers
+  inline int nLayers() const { return access()->implementation->nLayers(); }
+
   /// access the number of merged modules for given layer
   inline int mergedModules(const int layer) const { return access()->implementation->mergedModules(layer); }
-
 
   /// set the coordinate offset in theta
   inline void setOffsetTheta(double offset) const { access()->implementation->setOffsetTheta(offset); }
 
   /// set the grid size in theta
   inline void setGridSizeTheta(double cellSize) const { access()->implementation->setGridSizeTheta(cellSize); }
-
-  /// set the number of modules
-  inline void setNModules(int nModules) const { access()->implementation->setNModules(nModules); }
-
 
   /// access the field name used for theta
   inline const std::string& fieldNameTheta() const { return access()->implementation->fieldNameTheta(); }
@@ -108,12 +105,12 @@ public:
 
 
   /** \brief Returns a std::vector<double> of the cellDimensions of the given cell ID
-      in natural order of dimensions (dPhi, dTheta)
+      in natural order of dimensions (nModules, dTheta)
 
       Returns a std::vector of the cellDimensions of the given cell ID
-      \param cellID is ignored as all cells have the same dimension
+      \param cellID
       \return std::vector<double> size 2:
-      -# size in phi
+      -# size in module
       -# size in theta
   */
   inline std::vector<double> cellDimensions(const CellID& /*id*/) const {

--- a/Detector/DetSegmentation/include/DetSegmentation/GridTheta.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/GridTheta.h
@@ -69,7 +69,7 @@ public:
   inline void setFieldNameTheta(const std::string& fieldName) { m_thetaID = fieldName; }
   /// calculates the Cartesian position from cylindrical coordinates (r, phi, theta)
   inline Vector3D positionFromRThetaPhi(double ar, double atheta, double aphi) const {
-    return Vector3D(ar * std::cos(aphi), ar * std::sin(aphi),  ar * std::cos(atheta)/std::sin(atheta));
+    return Vector3D(ar * std::cos(aphi), ar * std::sin(aphi), ar * std::cos(atheta)/std::sin(atheta));
   }
   /// calculates the theta angle from Cartesian coordinates
   inline double thetaFromXYZ(const Vector3D& aposition) const {

--- a/Detector/DetSegmentation/include/DetSegmentation/GridTheta.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/GridTheta.h
@@ -69,7 +69,7 @@ public:
   inline void setFieldNameTheta(const std::string& fieldName) { m_thetaID = fieldName; }
   /// calculates the Cartesian position from cylindrical coordinates (r, phi, theta)
   inline Vector3D positionFromRThetaPhi(double ar, double atheta, double aphi) const {
-    return Vector3D(ar * std::cos(aphi), ar * std::sin(aphi), ar / std::tan(atheta));
+    return Vector3D(ar * std::cos(aphi), ar * std::sin(aphi),  ar * std::cos(atheta)/std::sin(atheta));
   }
   /// calculates the theta angle from Cartesian coordinates
   inline double thetaFromXYZ(const Vector3D& aposition) const {

--- a/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
@@ -17,6 +17,7 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const std::string& cellEn
   registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
   registerParameter("mergedModules", "Numbers of merged modules per layer", m_mergedModules, std::vector<int>());
   registerParameter("nModules", "Number of modules", m_nModules, 1545);
+
   //m_nModules = 1545;
   //m_alpha = 50./180.*M_PI;
   //m_rLayers = {217.28, 218.78, 222.28, 225.78, 229.28, 232.78, 236.28, 239.78, 243.28, 246.78, 250.28, 253.78, 257.33};
@@ -42,39 +43,11 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* deco
 /// determine the local position based on the cell ID
 Vector3D FCCSWGridModuleThetaMerged::position(const CellID& cID) const {
 
-  //debug
-  std::cout << "cellID: " << cID << std::endl;
+  // debug
+  // std::cout << "cellID: " << cID << std::endl;
 
   // cannot return for R=0 otherwise will lose phi info, return for R=1
   return positionFromRThetaPhi(1.0, theta(cID), phi(cID));
-
-  // version 1: determine radius/theta/phi from cellID
-  // return positionFromRThetaPhi(radius(cID), theta(cID), phi(cID));
-
-  // version 2: use detector position 
-  // read in outGlobal the x-y-z coordinates of the 1st of the merged group of cells
-  /*
-  VolumeID vID = cID;
-  _decoder->set(vID, m_thetaID, 0);
-  auto detelement = m_volman.lookupDetElement(vID);
-  const auto& transformMatrix = detelement.nominal().worldTransformation();
-  double outGlobal[3];
-  double inLocal[] = {0, 0, 0};
-  transformMatrix.LocalToMaster(inLocal, outGlobal);
-  // now get R-phi
-  Vector3D position(outGlobal[0],outGlobal[1],outGlobal[2]);
-  double _radius = std::sqrt(outGlobal[0]*outGlobal[0] + outGlobal[1]*outGlobal[1]);
-  double _phi = std::atan2(outGlobal[1], outGlobal[0]);
-  // now add shifts in phi due to merging of modules and theta cells
-  int layer = _decoder->get(cID, m_layerID);
-  if (m_mergedModules[layer]>1) {
-    _phi += (m_mergedModules[layer]-1) * M_PI / m_nModules ;
-    // should we check (and adjust) that phi is in -pi..pi? or 0..2pi?
-  }
-  // get theta from grid
-  double _theta = theta(cID);
-  return positionFromRThetaPhi(_radius, _theta, _phi);
-  */
 }
 
 /// determine the cell ID based on the global position
@@ -152,13 +125,12 @@ double FCCSWGridModuleThetaMerged::phi(const CellID& cID) const {
   double phi = 0.0;
   if (m_mergedModules[layer]>1) {
     phi += (m_mergedModules[layer]-1) * M_PI / m_nModules ;
-    // should we check (and adjust) that phi is in -pi..pi? or 0..2pi?
   }
 
-  //debug
-  std::cout << "layer: " << layer << std::endl;
-  std::cout << "merged modules: " << m_mergedModules[layer] << std::endl;
-  std::cout << "phi: " << phi << std::endl;
+  // debug
+  // std::cout << "layer: " << layer << std::endl;
+  // std::cout << "merged modules: " << m_mergedModules[layer] << std::endl;
+  // std::cout << "phi: " << phi << std::endl;
 
   return phi;
 }
@@ -170,17 +142,21 @@ double FCCSWGridModuleThetaMerged::theta(const CellID& cID) const {
 
   // retrieve theta bin from cellID and determine theta position
   CellID thetaValue = _decoder->get(cID, m_thetaID);
-  // debug
-  std::cout << "theta bin: " << thetaValue << std::endl;
   double _theta = binToPosition(thetaValue, m_gridSizeTheta, m_offsetTheta);
-  std::cout << "gridSizeTheta, offsetTheta: " << m_gridSizeTheta << " , " << m_offsetTheta << std::endl;
+
   // adjust return value if cells are merged along theta in this layer
   // shift by (N-1)*half theta grid size
   if (m_mergedCellsTheta[layer]>1) {
     _theta += (m_mergedCellsTheta[layer]-1) * m_gridSizeTheta / 2.0 ;
   }
 
-  std::cout << "theta: " << _theta << std::endl;
+  // debug
+  // std::cout << "layer: " << layer << std::endl;
+  // std::cout << "theta bin: " << thetaValue << std::endl;
+  // std::cout << "gridSizeTheta, offsetTheta: " << m_gridSizeTheta << " , " << m_offsetTheta << std::endl;
+  // std::cout << "merged cells: " << m_mergedCellsTheta[layer] << std::endl;
+  // std::cout << "theta: " << _theta << std::endl;
+
   return _theta;
 }
 

--- a/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
@@ -57,10 +57,8 @@ CellID FCCSWGridModuleThetaMerged::cellID(const Vector3D& /* localPosition */, c
   int thetaBin = positionToBin(lTheta, m_gridSizeTheta, m_offsetTheta);
 
   // adjust theta bin if cells are merged along theta in this layer
-  if (m_mergedCellsTheta[layer]>1) {
-    if ((thetaBin % m_mergedCellsTheta[layer])>0)
-      thetaBin -= (thetaBin % m_mergedCellsTheta[layer]);
-  }
+  // assume that m_mergedCellsTheta[layer]>=1
+  thetaBin -= (thetaBin % m_mergedCellsTheta[layer]);
 
   // set theta field of cellID
   _decoder->set(cID, m_thetaID, thetaBin);
@@ -69,10 +67,8 @@ CellID FCCSWGridModuleThetaMerged::cellID(const Vector3D& /* localPosition */, c
   int module = _decoder->get(vID, m_moduleID);
 
   // adjust module number if modules are merged in this layer
-  if (m_mergedModules[layer]>1) {
-    if ((module % m_mergedModules[layer])>0)
-      module -= (module % m_mergedModules[layer]);
-  }
+  // assume that m_mergedModules[layer]>=1
+  module -= (module % m_mergedModules[layer]);
 
   // set module field of cellID
   _decoder->set(cID, m_moduleID, module);
@@ -88,14 +84,12 @@ CellID FCCSWGridModuleThetaMerged::cellID(const Vector3D& /* localPosition */, c
 /// by the positioning tool
 double FCCSWGridModuleThetaMerged::phi(const CellID& cID) const {
 
-  // retrieve layer, radius and module
+  // retrieve layer
   int layer = _decoder->get(cID, m_layerID);
 
-  // calculate phi offset due to merging 
-  double phi = 0.0;
-  if (m_mergedModules[layer]>1) {
-    phi += (m_mergedModules[layer]-1) * M_PI / m_nModules ;
-  }
+  // calculate phi offset due to merging
+  // assume that m_mergedModules[layer]>=1
+  double phi = (m_mergedModules[layer]-1) * M_PI / m_nModules ;
 
   // debug
   // std::cout << "layer: " << layer << std::endl;
@@ -118,9 +112,8 @@ double FCCSWGridModuleThetaMerged::theta(const CellID& cID) const {
 
   // adjust return value if cells are merged along theta in this layer
   // shift by (N-1)*half theta grid size
-  if (m_mergedCellsTheta[layer]>1) {
-    _theta += (m_mergedCellsTheta[layer]-1) * m_gridSizeTheta / 2.0 ;
-  }
+  // assume that m_mergedCellsTheta[layer]>=1
+  _theta += (m_mergedCellsTheta[layer]-1) * m_gridSizeTheta / 2.0 ;
 
   // debug
   // std::cout << "layer: " << layer << std::endl;

--- a/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
@@ -18,6 +18,7 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const std::string& cellEn
   registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
   registerParameter("mergedModules", "Numbers of merged modules per layer", m_mergedModules, std::vector<int>());
   GetNModulesFromGeom();
+  GetNLayersFromGeom();
 }
 
 FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* decoder) : GridTheta(decoder) {
@@ -29,9 +30,9 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* deco
   registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
   registerIdentifier("identifier_module", "Cell ID identifier for module", m_moduleID, "module");
   registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
-  registerParameter("mergedModules", "Numbers of merged cells in phi per layer", m_mergedModules, std::vector<int>());
-  registerParameter("nModules", "Number of modules", m_nModules, 1545);
+  registerParameter("mergedModules", "Numbers of merged modules per layer", m_mergedModules, std::vector<int>());
   GetNModulesFromGeom();
+  GetNLayersFromGeom();
 }
 
 void FCCSWGridModuleThetaMerged::GetNModulesFromGeom() {
@@ -45,6 +46,19 @@ void FCCSWGridModuleThetaMerged::GetNModulesFromGeom() {
   }
   std::cout << "Number of modules read from detector metadata and used in readout class: " << m_nModules << std::endl;
 }
+
+void FCCSWGridModuleThetaMerged::GetNLayersFromGeom() {
+  dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
+  try {
+    m_nLayers = dd4hepgeo->constant<int>("ECalBarrelNumLayers");
+  }
+  catch(...) {
+    std::cout << "Number of layers not found in detector metadata, exiting..." << std::endl;
+    exit(1);
+  }
+  std::cout << "Number of layers read from detector metadata and used in readout class: " << m_nLayers << std::endl;
+}
+
 /// determine the local position based on the cell ID
 Vector3D FCCSWGridModuleThetaMerged::position(const CellID& cID) const {
 

--- a/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
@@ -1,0 +1,188 @@
+#include "DetSegmentation/FCCSWGridModuleThetaMerged.h"
+
+#include <iostream>
+
+namespace dd4hep {
+namespace DDSegmentation {
+
+/// default constructor using an encoding string
+FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const std::string& cellEncoding) : GridTheta(cellEncoding) {
+  // define type and description
+  _type = "FCCSWGridModuleThetaMerged";
+  _description = "Module-theta segmentation with per-layer merging along theta and/or module";
+
+  // register all necessary parameters (additional to those registered in GridTheta)
+  registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
+  registerIdentifier("identifier_module", "Cell ID identifier for readout module", m_moduleID, "module");
+  registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
+  registerParameter("mergedModules", "Numbers of merged modules per layer", m_mergedModules, std::vector<int>());
+  registerParameter("nModules", "Number of modules", m_nModules, 1545);
+  //m_nModules = 1545;
+  //m_alpha = 50./180.*M_PI;
+  //m_rLayers = {217.28, 218.78, 222.28, 225.78, 229.28, 232.78, 236.28, 239.78, 243.28, 246.78, 250.28, 253.78, 257.33};
+}
+
+FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* decoder) : GridTheta(decoder) {
+  // define type and description
+  _type = "FCCSWGridModuleThetaMerged";
+  _description = "Module-theta segmentation with per-layer merging along theta and/or module";
+
+  // register all necessary parameters (additional to those registered in GridTheta)
+  registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
+  registerIdentifier("identifier_module", "Cell ID identifier for module", m_moduleID, "module");
+  registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
+  registerParameter("mergedModules", "Numbers of merged cells in phi per layer", m_mergedModules, std::vector<int>());
+  registerParameter("nModules", "Number of modules", m_nModules, 1545);
+
+  //m_nModules = 1545;
+  //m_alpha = 50./180.*M_PI;
+  //m_rLayers = {217.28, 218.78, 222.28, 225.78, 229.28, 232.78, 236.28, 239.78, 243.28, 246.78, 250.28, 253.78, 257.33};
+}
+
+/// determine the local position based on the cell ID
+Vector3D FCCSWGridModuleThetaMerged::position(const CellID& cID) const {
+
+  //debug
+  std::cout << "cellID: " << cID << std::endl;
+
+  // cannot return for R=0 otherwise will lose phi info, return for R=1
+  return positionFromRThetaPhi(1.0, theta(cID), phi(cID));
+
+  // version 1: determine radius/theta/phi from cellID
+  // return positionFromRThetaPhi(radius(cID), theta(cID), phi(cID));
+
+  // version 2: use detector position 
+  // read in outGlobal the x-y-z coordinates of the 1st of the merged group of cells
+  /*
+  VolumeID vID = cID;
+  _decoder->set(vID, m_thetaID, 0);
+  auto detelement = m_volman.lookupDetElement(vID);
+  const auto& transformMatrix = detelement.nominal().worldTransformation();
+  double outGlobal[3];
+  double inLocal[] = {0, 0, 0};
+  transformMatrix.LocalToMaster(inLocal, outGlobal);
+  // now get R-phi
+  Vector3D position(outGlobal[0],outGlobal[1],outGlobal[2]);
+  double _radius = std::sqrt(outGlobal[0]*outGlobal[0] + outGlobal[1]*outGlobal[1]);
+  double _phi = std::atan2(outGlobal[1], outGlobal[0]);
+  // now add shifts in phi due to merging of modules and theta cells
+  int layer = _decoder->get(cID, m_layerID);
+  if (m_mergedModules[layer]>1) {
+    _phi += (m_mergedModules[layer]-1) * M_PI / m_nModules ;
+    // should we check (and adjust) that phi is in -pi..pi? or 0..2pi?
+  }
+  // get theta from grid
+  double _theta = theta(cID);
+  return positionFromRThetaPhi(_radius, _theta, _phi);
+  */
+}
+
+/// determine the cell ID based on the global position
+CellID FCCSWGridModuleThetaMerged::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition,
+                          const VolumeID& vID) const {
+  CellID cID = vID;
+
+  // retrieve layer (since merging depends on layer)
+  int layer = _decoder->get(vID, m_layerID);
+
+  // retrieve theta
+  double lTheta = thetaFromXYZ(globalPosition);
+
+  // calculate theta bin with original segmentation
+  int thetaBin = positionToBin(lTheta, m_gridSizeTheta, m_offsetTheta);
+
+  // adjust theta bin if cells are merged along theta in this layer
+  if (m_mergedCellsTheta[layer]>1) {
+    if ((thetaBin % m_mergedCellsTheta[layer])>0)
+      thetaBin -= (thetaBin % m_mergedCellsTheta[layer]);
+  }
+
+  // set theta field of cellID
+  _decoder->set(cID, m_thetaID, thetaBin);
+
+  // retrieve module number
+  int module = _decoder->get(vID, m_moduleID);
+
+  // adjust module number if modules are merged in this layer
+  if (m_mergedModules[layer]>1) {
+    if ((module % m_mergedModules[layer])>0)
+      module -= (module % m_mergedModules[layer]);
+  }
+
+  // set module field of cellID
+  _decoder->set(cID, m_moduleID, module);
+
+  return cID;
+}
+
+/// determine the radius based on the cell ID
+/*
+double FCCSWGridModuleThetaMerged::radius(const CellID& cID) const {
+
+  int layer = _decoder->get(cID, m_layerID);
+
+  return (m_rLayers[layer+1]+m_rLayers[layer])/2.0;
+}
+*/
+
+/// determine the azimuth based on the cell ID
+double FCCSWGridModuleThetaMerged::phi(const CellID& cID) const {
+
+  // retrieve layer, radius and module
+  int layer = _decoder->get(cID, m_layerID);
+
+  /*
+  // calculate phi of volume
+  int module = _decoder->get(cID, m_moduleID);
+  double r = radius(cID);
+
+  // calculate initial phi
+  // not sure this is fully consistent with Geant4 positioning!!!!
+  // I need to find out which phi is module=0
+  double phi = 2.0*M_PI/m_nModules * (module) - m_alpha;
+
+  // calculate phi offset due to electrode inclination
+  double r0 = m_rLayers[0];
+  double L = -r0*cos(m_alpha) + std::sqrt(r*r-r0*r0*std::sin(m_alpha)*std::sin(m_alpha));
+  double dphi = std::acos((r*r+r0*r0-L*L)/(2*r*r0));
+  phi += dphi;
+  */
+
+  // calculate phi offset due to merging 
+  double phi = 0.0;
+  if (m_mergedModules[layer]>1) {
+    phi += (m_mergedModules[layer]-1) * M_PI / m_nModules ;
+    // should we check (and adjust) that phi is in -pi..pi? or 0..2pi?
+  }
+
+  //debug
+  std::cout << "layer: " << layer << std::endl;
+  std::cout << "merged modules: " << m_mergedModules[layer] << std::endl;
+  std::cout << "phi: " << phi << std::endl;
+
+  return phi;
+}
+
+double FCCSWGridModuleThetaMerged::theta(const CellID& cID) const {
+
+  // retrieve layer
+  int layer = _decoder->get(cID, m_layerID);
+
+  // retrieve theta bin from cellID and determine theta position
+  CellID thetaValue = _decoder->get(cID, m_thetaID);
+  // debug
+  std::cout << "theta bin: " << thetaValue << std::endl;
+  double _theta = binToPosition(thetaValue, m_gridSizeTheta, m_offsetTheta);
+  std::cout << "gridSizeTheta, offsetTheta: " << m_gridSizeTheta << " , " << m_offsetTheta << std::endl;
+  // adjust return value if cells are merged along theta in this layer
+  // shift by (N-1)*half theta grid size
+  if (m_mergedCellsTheta[layer]>1) {
+    _theta += (m_mergedCellsTheta[layer]-1) * m_gridSizeTheta / 2.0 ;
+  }
+
+  std::cout << "theta: " << _theta << std::endl;
+  return _theta;
+}
+
+}
+}

--- a/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
@@ -17,10 +17,6 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const std::string& cellEn
   registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
   registerParameter("mergedModules", "Numbers of merged modules per layer", m_mergedModules, std::vector<int>());
   registerParameter("nModules", "Number of modules", m_nModules, 1545);
-
-  //m_nModules = 1545;
-  //m_alpha = 50./180.*M_PI;
-  //m_rLayers = {217.28, 218.78, 222.28, 225.78, 229.28, 232.78, 236.28, 239.78, 243.28, 246.78, 250.28, 253.78, 257.33};
 }
 
 FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* decoder) : GridTheta(decoder) {
@@ -34,10 +30,6 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* deco
   registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
   registerParameter("mergedModules", "Numbers of merged cells in phi per layer", m_mergedModules, std::vector<int>());
   registerParameter("nModules", "Number of modules", m_nModules, 1545);
-
-  //m_nModules = 1545;
-  //m_alpha = 50./180.*M_PI;
-  //m_rLayers = {217.28, 218.78, 222.28, 225.78, 229.28, 232.78, 236.28, 239.78, 243.28, 246.78, 250.28, 253.78, 257.33};
 }
 
 /// determine the local position based on the cell ID
@@ -88,38 +80,16 @@ CellID FCCSWGridModuleThetaMerged::cellID(const Vector3D& /* localPosition */, c
   return cID;
 }
 
-/// determine the radius based on the cell ID
-/*
-double FCCSWGridModuleThetaMerged::radius(const CellID& cID) const {
-
-  int layer = _decoder->get(cID, m_layerID);
-
-  return (m_rLayers[layer+1]+m_rLayers[layer])/2.0;
-}
-*/
-
 /// determine the azimuth based on the cell ID
+/// the value returned is the relative shift in phi
+/// with respect to the first module in the group of
+/// merged ones - which will be then added on top of
+/// the phi of the volume containing the first cell
+/// by the positioning tool
 double FCCSWGridModuleThetaMerged::phi(const CellID& cID) const {
 
   // retrieve layer, radius and module
   int layer = _decoder->get(cID, m_layerID);
-
-  /*
-  // calculate phi of volume
-  int module = _decoder->get(cID, m_moduleID);
-  double r = radius(cID);
-
-  // calculate initial phi
-  // not sure this is fully consistent with Geant4 positioning!!!!
-  // I need to find out which phi is module=0
-  double phi = 2.0*M_PI/m_nModules * (module) - m_alpha;
-
-  // calculate phi offset due to electrode inclination
-  double r0 = m_rLayers[0];
-  double L = -r0*cos(m_alpha) + std::sqrt(r*r-r0*r0*std::sin(m_alpha)*std::sin(m_alpha));
-  double dphi = std::acos((r*r+r0*r0-L*L)/(2*r*r0));
-  phi += dphi;
-  */
 
   // calculate phi offset due to merging 
   double phi = 0.0;
@@ -135,6 +105,8 @@ double FCCSWGridModuleThetaMerged::phi(const CellID& cID) const {
   return phi;
 }
 
+/// determine the polar angle based on the cell ID and the
+/// number of merged theta cells
 double FCCSWGridModuleThetaMerged::theta(const CellID& cID) const {
 
   // retrieve layer

--- a/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridModuleThetaMerged.cpp
@@ -1,6 +1,7 @@
 #include "DetSegmentation/FCCSWGridModuleThetaMerged.h"
 
 #include <iostream>
+#include "DD4hep/Detector.h"
 
 namespace dd4hep {
 namespace DDSegmentation {
@@ -16,7 +17,7 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const std::string& cellEn
   registerIdentifier("identifier_module", "Cell ID identifier for readout module", m_moduleID, "module");
   registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
   registerParameter("mergedModules", "Numbers of merged modules per layer", m_mergedModules, std::vector<int>());
-  registerParameter("nModules", "Number of modules", m_nModules, 1545);
+  GetNModulesFromGeom();
 }
 
 FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* decoder) : GridTheta(decoder) {
@@ -30,8 +31,20 @@ FCCSWGridModuleThetaMerged::FCCSWGridModuleThetaMerged(const BitFieldCoder* deco
   registerParameter("mergedCells_Theta", "Numbers of merged cells in theta per layer", m_mergedCellsTheta, std::vector<int>());
   registerParameter("mergedModules", "Numbers of merged cells in phi per layer", m_mergedModules, std::vector<int>());
   registerParameter("nModules", "Number of modules", m_nModules, 1545);
+  GetNModulesFromGeom();
 }
 
+void FCCSWGridModuleThetaMerged::GetNModulesFromGeom() {
+  dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
+  try {
+    m_nModules = dd4hepgeo->constant<int>("ECalBarrelNumPlanes");
+  }
+  catch(...) {
+    std::cout << "Number of modules not found in detector metadata, exiting..." << std::endl;
+    exit(1);
+  }
+  std::cout << "Number of modules read from detector metadata and used in readout class: " << m_nModules << std::endl;
+}
 /// determine the local position based on the cell ID
 Vector3D FCCSWGridModuleThetaMerged::position(const CellID& cID) const {
 

--- a/Detector/DetSegmentation/src/FCCSWGridModuleThetaMergedHandle.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridModuleThetaMergedHandle.cpp
@@ -1,0 +1,4 @@
+#include "DetSegmentation/FCCSWGridModuleThetaMergedHandle.h"
+#include "DD4hep/detail/Handle.inl"
+
+DD4HEP_INSTANTIATE_HANDLE_UNNAMED(dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged);

--- a/Detector/DetSegmentation/src/GridEta.cpp
+++ b/Detector/DetSegmentation/src/GridEta.cpp
@@ -11,7 +11,7 @@ GridEta::GridEta(const std::string& cellEncoding) : Segmentation(cellEncoding) {
   _description = "Eeta segmentation in the global coordinates";
 
   // register all necessary parameters
-  registerParameter("grid_size_eta", "Cell size in Eta", m_gridSizeEta, 1., SegmentationParameter::LengthUnit);
+  registerParameter("grid_size_eta", "Cell size in eta", m_gridSizeEta, 1., SegmentationParameter::LengthUnit);
   registerParameter("offset_eta", "Angular offset in eta", m_offsetEta, 0., SegmentationParameter::AngleUnit, true);
   registerIdentifier("identifier_eta", "Cell ID identifier for eta", m_etaID, "eta");
 }
@@ -19,10 +19,10 @@ GridEta::GridEta(const std::string& cellEncoding) : Segmentation(cellEncoding) {
 GridEta::GridEta(const BitFieldCoder* decoder) : Segmentation(decoder) {
   // define type and description
   _type = "GridEta";
-  _description = "Eeta segmentation in the global coordinates";
+  _description = "Eta segmentation in the global coordinates";
 
   // register all necessary parameters
-  registerParameter("grid_size_eta", "Cell size in Eta", m_gridSizeEta, 1., SegmentationParameter::LengthUnit);
+  registerParameter("grid_size_eta", "Cell size in eta", m_gridSizeEta, 1., SegmentationParameter::LengthUnit);
   registerParameter("offset_eta", "Angular offset in eta", m_offsetEta, 0., SegmentationParameter::AngleUnit, true);
   registerIdentifier("identifier_eta", "Cell ID identifier for eta", m_etaID, "eta");
 }
@@ -46,7 +46,7 @@ CellID GridEta::cellID(const Vector3D& /* localPosition */, const Vector3D& glob
 //  return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
 //}
 
-/// determine the polar angle theta based on the cell ID
+/// determine the pseudorapidity based on the cell ID
 double GridEta::eta(const CellID& cID) const {
   CellID etaValue = _decoder->get(cID, m_etaID);
   return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);

--- a/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
+++ b/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
@@ -17,6 +17,9 @@ DECLARE_SEGMENTATION(GridTheta, create_segmentation<dd4hep::DDSegmentation::Grid
 #include "DetSegmentation/FCCSWGridPhiTheta.h"
 DECLARE_SEGMENTATION(FCCSWGridPhiTheta, create_segmentation<dd4hep::DDSegmentation::FCCSWGridPhiTheta>)
 
+#include "DetSegmentation/FCCSWGridModuleThetaMerged.h"
+DECLARE_SEGMENTATION(FCCSWGridModuleThetaMerged, create_segmentation<dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged>)
+
 #include "DetSegmentation/FCCSWGridPhiEta.h"
 DECLARE_SEGMENTATION(FCCSWGridPhiEta, create_segmentation<dd4hep::DDSegmentation::FCCSWGridPhiEta>)
 


### PR DESCRIPTION
This code implements a readout for the ECAL with inclined electrodes based on module number and theta ID, with the possibility to group adjacent cells (in theta and or in module direction) together.
See my presentation here: https://indico.cern.ch/event/1299615/contributions/5475445/attachments/2679458/4647792/2023_07_06%20-%20Noble%20liquid%20calorimeter%20digitisation.pdf

Tagging @gartrog , @BrieucF 