### PR TITLE
Make topoclustering work with new theta-module merged readout 

### DIFF
--- a/Detector/DetCommon/include/DetCommon/DetUtils.h
+++ b/Detector/DetCommon/include/DetCommon/DetUtils.h
@@ -4,7 +4,7 @@
 // FCCSW
 #include "DetSegmentation/FCCSWGridPhiEta.h"
 #include "DetSegmentation/FCCSWGridPhiTheta.h"
-
+#include "DetSegmentation/FCCSWGridModuleThetaMerged.h"
 
 // DD4hep
 #include "DD4hep/DetFactoryHelper.h"
@@ -84,6 +84,25 @@ std::vector<uint64_t> neighbours(const dd4hep::DDSegmentation::BitFieldCoder& aD
                                  const std::vector<bool>& aFieldCyclic = {false, false, false, false},
                                  bool aDiagonal = true);
 
+/** Special version of the neighbours function for the readout with module and theta merged cells
+ *  Compared to the standard version, it needs a reference to the segmentation class to
+ *  access the number of merged cells per layer. The other parameters and return value are the same
+ *   @param[in] aSeg Reference to the segmentation object.
+ *   @param[in] aDecoder Handle to the bitfield decoder.
+ *   @param[in] aFieldNames Names of the fields for which neighbours are found.
+ *   @param[in] aFieldExtremes Minimal and maximal values for the fields.
+ *   @param[in] aCellId ID of cell.
+ *   @param[in] aDiagonal If diagonal neighbours should be included (all combinations of fields).
+ *   return Vector of neighbours.
+ */
+std::vector<uint64_t> neighbours_ModuleThetaMerged(const dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged& aSeg,
+                                 const dd4hep::DDSegmentation::BitFieldCoder& aDecoder,
+                                 const std::vector<std::string>& aFieldNames,
+                                 const std::vector<std::pair<int, int>>& aFieldExtremes,
+                                 uint64_t aCellId,
+                                 const std::vector<bool>& aFieldCyclic = {false, false, false, false},
+                                 bool aDiagonal = false);
+
 /** Get minimal and maximal values that can be decoded in the fields of the bitfield.
  *   @param[in] aDecoder Handle to the bitfield decoder.
  *   @param[in] aFieldNames Names of the fields for which extremes are found.
@@ -116,17 +135,30 @@ CLHEP::Hep3Vector coneDimensions(uint64_t aVolumeId);
  */
 std::array<double, 2> tubeEtaExtremes(uint64_t aVolumeId);
 
+// GM: unnneded, kept for debug, will remove before merge
+  /** Get the extrema in theta of a tube or cone volume.
+ *   @param[in] aVolumeId The volume ID.
+ *   return Pseudorapidity extrema (eta_min, eta_max).
+ */
+//std::array<double, 2> tubeThetaExtremes(uint64_t aVolumeId);
+
 /** Get the extrema in pseudorapidity of an envelope.
  *   @param[in] aVolumeId The volume ID.
  *   return Pseudorapidity extrema (eta_min, eta_max).
  */
 std::array<double, 2> envelopeEtaExtremes(uint64_t aVolumeId);
 
+// GM UNNEEDED  CAN USE PREVIOUS ONE AND CONVERT ETA TO THETA
+//std::array<double, 2> envelopeThetaExtremes(uint64_t aVolumeId);
+
 /** Get the extrema in pseudorapidity of a volume. First try to match tube or cone, if it fails use an envelope shape.
  *   @param[in] aVolumeId The volume ID.
  *   return Pseudorapidity extrema (eta_min, eta_max).
  */
 std::array<double, 2> volumeEtaExtremes(uint64_t aVolumeId);
+
+// GM UNNEEDED  CAN USE PREVIOUS ONE AND CONVERT ETA TO THETA
+//std::array<double, 2> volumeThetaExtremes(uint64_t aVolumeId);
 
 /** Get the number of cells for the volume and a given Cartesian XY segmentation.
  *   For an example see: Test/TestReconstruction/tests/options/testcellcountingXYZ.py.
@@ -146,16 +178,18 @@ std::array<uint, 2> numberOfCells(uint64_t aVolumeId, const dd4hep::DDSegmentati
  */
 std::array<uint, 3> numberOfCells(uint64_t aVolumeId, const dd4hep::DDSegmentation::CartesianGridXYZ& aSeg);
 
-/** Get the number of cells for the volume and a given Phi-Eta segmentation.
+/** Get the number of cells for the volume and a given Phi-Eta / Phi-Theta / Module-Theta segmentation.
  *   It is assumed that the volume has a cylindrical shape (and full azimuthal coverage)
  *   and that it is centred at (0,0,0).
  *   For an example see: Test/TestReconstruction/tests/options/testcellcountingPhiEta.py.
  *   @warning No offset in segmentation is currently taken into account.
  *   @param[in] aVolumeId The volume for which the cells are counted.
  *   @param[in] aSeg Handle to the segmentation of the volume.
- *   return Array of the number of cells in (phi, eta) and the minimum eta ID.
+ *   return Array of the number of cells in (phi, eta) / (phi, theta) / (module, theta) and the minimum eta / theta ID.
  */
 std::array<uint, 3> numberOfCells(uint64_t aVolumeId, const dd4hep::DDSegmentation::FCCSWGridPhiEta& aSeg);
+std::array<uint, 3> numberOfCells(uint64_t aVolumeId, const dd4hep::DDSegmentation::FCCSWGridPhiTheta& aSeg);
+std::array<uint, 3> numberOfCells(uint64_t aVolumeId, const dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged& aSeg);
 
 /** Get the number of cells for the volume and a given R-phi segmentation.
  *   It is assumed that the volume has a cylindrical shape - TGeoTube (and full azimuthal coverage)

--- a/Detector/DetCommon/include/DetCommon/DetUtils.h
+++ b/Detector/DetCommon/include/DetCommon/DetUtils.h
@@ -134,30 +134,17 @@ CLHEP::Hep3Vector coneDimensions(uint64_t aVolumeId);
  */
 std::array<double, 2> tubeEtaExtremes(uint64_t aVolumeId);
 
-// GM: unnneded, kept for debug, will remove before merge
-  /** Get the extrema in theta of a tube or cone volume.
- *   @param[in] aVolumeId The volume ID.
- *   return Pseudorapidity extrema (eta_min, eta_max).
- */
-//std::array<double, 2> tubeThetaExtremes(uint64_t aVolumeId);
-
 /** Get the extrema in pseudorapidity of an envelope.
  *   @param[in] aVolumeId The volume ID.
  *   return Pseudorapidity extrema (eta_min, eta_max).
  */
 std::array<double, 2> envelopeEtaExtremes(uint64_t aVolumeId);
 
-// GM UNNEEDED  CAN USE PREVIOUS ONE AND CONVERT ETA TO THETA
-//std::array<double, 2> envelopeThetaExtremes(uint64_t aVolumeId);
-
 /** Get the extrema in pseudorapidity of a volume. First try to match tube or cone, if it fails use an envelope shape.
  *   @param[in] aVolumeId The volume ID.
  *   return Pseudorapidity extrema (eta_min, eta_max).
  */
 std::array<double, 2> volumeEtaExtremes(uint64_t aVolumeId);
-
-// GM UNNEEDED  CAN USE PREVIOUS ONE AND CONVERT ETA TO THETA
-//std::array<double, 2> volumeThetaExtremes(uint64_t aVolumeId);
 
 /** Get the number of cells for the volume and a given Cartesian XY segmentation.
  *   For an example see: Test/TestReconstruction/tests/options/testcellcountingXYZ.py.

--- a/Detector/DetCommon/include/DetCommon/DetUtils.h
+++ b/Detector/DetCommon/include/DetCommon/DetUtils.h
@@ -100,7 +100,6 @@ std::vector<uint64_t> neighbours_ModuleThetaMerged(const dd4hep::DDSegmentation:
                                  const std::vector<std::string>& aFieldNames,
                                  const std::vector<std::pair<int, int>>& aFieldExtremes,
                                  uint64_t aCellId,
-                                 const std::vector<bool>& aFieldCyclic = {false, false, false, false},
                                  bool aDiagonal = false);
 
 /** Get minimal and maximal values that can be decoded in the fields of the bitfield.

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -23,7 +23,8 @@
     <!-- Inclination angle of the lead plates -->
     <constant name="InclinationAngle" value="50*degree"/>
     <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
-    <constant name="LArGapThickness" value="1.239749*2*mm"/>
+    <!--constant name="LArGapThickness" value="1.239749*2*mm"/-->
+    <constant name="LArGapThickness" value="1.256*2*mm"/>
 
     <!-- Air margin, thicknesses of cryostat and LAr bath -->
     <constant name="AirMarginThickness" value="54*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
@@ -58,7 +59,7 @@
     <!-- When employing trapezoidal planes Pb_thickness corresponds to the minimum thickness, i.e at the front of the calo -->
     <constant name="Pb_thickness" value="1.80*mm"/>
     <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
-    <constant name="ECalBarrelNumPlanes" value="1545"/>
+    <constant name="ECalBarrelNumPlanes" value="1536"/>
     <constant name="ECalBarrelNumLayers" value="12"/>
     <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
     <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
@@ -83,13 +84,13 @@
     <!-- readout for the simulation, with the baseline merging: 2x along the module direction in each layer; 4x along theta in each layer except layer 1 -->
     <!-- the lists mergedCells_Theta and mergedModules define the number of cells to group together in the theta and module direction as a function of the layer -->
     <readout name="ECalBarrelModuleThetaMerged">
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1536" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
 
     <!-- example of adding a second readout for the reconstruction, to compare the two -->
     <readout name="ECalBarrelModuleThetaMerged2">
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1536" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -67,7 +67,7 @@
          taking into account the angular projection effect -->
     <!-- <constant name="Pb_thickness_max" value="1.3 * Pb_thickness * EMBarrel_rmax/EMBarrel_rmin *
          cos(InclinationAngle - phi) / cos(InclinationAngle)" />-->
-    <constant name="Pb_thickness_max" value="Pb_thickness" />
+    <constant name="Pb_thickness_max" value="Pb_thickness"/>
     <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
     <constant name="Steel_thickness" value="0.1*mm"/>
     <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
@@ -77,7 +77,7 @@
   </define>
 
   <display>
-    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true" />
+    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true"/>
   </display>
 
   <readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_calibration.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_calibration.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" ?><lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="FCCee_ECalBarrel" title="Settings for FCCee Inclined ECal Barrel Calorimeter" author="M.Aleksa,J.Faltova,A.Zaborowska, V. Volkl" url="no" status="development" version="1.0">
+    <comment>
+      Settings for the inclined EM calorimeter.
+      The barrel is filled with liquid argon. Passive material includes lead in the middle and steal on the outside, glued together.
+      Passive plates are inclined by a certain angle from the radial direction.
+      In between of two passive plates there is a readout.
+      Space between the plate and readout is of trapezoidal shape and filled with liquid argon.
+      Definition of sizes, visualization settings, readout and longitudinal segmentation are specified. 
+    </comment>
+  </info>
+
+  <define>
+    <!-- Inclination angle of the lead plates -->
+    <constant name="InclinationAngle" value="50*degree"/>
+    <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
+    <constant name="LArGapThickness" value="1.239749*2*mm"/>
+
+    <!-- Air margin, thicknesses of cryostat and LAr bath -->
+    <constant name="AirMarginThickness" value="54*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
+
+    <constant name="CryoBarrelFrontWarm" value="10*mm"/>   <!-- Al solid corresponding to 0.11 X0 -->
+    <constant name="CryoBarrelFrontCold" value="3.8*mm"/>  <!-- Al solid equivalent of 0.043 X0 sandwich CFRP -->
+    <constant name="CryoBarrelFront" value="CryoBarrelFrontWarm+CryoBarrelFrontCold"/>
+
+    <constant name="CryoBarrelBackCold" value="30*mm"/>   <!-- Al solid corresponding to 0.34 X0 -->
+    <constant name="CryoBarrelBackWarm" value="2.7*mm"/>  <!-- Al solid equivalent of 0.03 X0 sandwich CFRP -->
+    <constant name="SolenoidBarrel" value="70*mm"/>    <!-- Al solenoid with thickness of 0.8 X0 -->
+    <constant name="CryoBarrelBack" value="CryoBarrelBackWarm+SolenoidBarrel+CryoBarrelBackCold"/>
+
+    <constant name="CryoBarrelSideWarm" value="30*mm"/>
+    <constant name="CryoBarrelSideCold" value="3.8*mm"/>
+    <constant name="CryoBarrelSide" value="CryoBarrelSideWarm+CryoBarrelSideCold"/>
+
+    <constant name="LArBathThicknessFront" value="5*mm"/>
+    <constant name="LArBathThicknessBack" value="40*mm"/>
+
+    <!-- air margin around calorimeter -->
+    <constant name="BarCryoECal_rmin" value="BarECal_rmin+AirMarginThickness"/>
+    <constant name="BarCryoECal_rmax" value="BarECal_rmax-AirMarginThickness"/>
+    <constant name="BarCryoECal_dz" value="BarECal_dz"/>
+    <!-- calorimeter active volume -->
+    <constant name="EMBarrel_rmin" value="BarCryoECal_rmin+CryoBarrelFront+LArBathThicknessFront"/>
+    <constant name="EMBarrel_rmax" value="BarCryoECal_rmax-CryoBarrelBack-LArBathThicknessBack"/>
+    <constant name="EMBarrel_dz" value="BarECal_dz-CryoBarrelSide"/>
+    <!-- thickness of active volume between two absorber plates at EMBarrel_rmin, measuring perpendicular to the readout plate -->
+    <constant name="LAr_thickness" value="LArGapThickness"/>
+    <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
+    <!-- When employing trapezoidal planes Pb_thickness corresponds to the minimum thickness, i.e at the front of the calo -->
+    <constant name="Pb_thickness" value="1.80*mm"/>
+    <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
+    <constant name="ECalBarrelNumPlanes" value="1545"/>
+    <constant name="ECalBarrelNumLayers" value="12"/>
+    <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
+    <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
+    <!-- approximate constant sampling fraction: make the absorber grow linearly with the radius,
+         taking into account the angular projection effect -->
+    <!-- <constant name="Pb_thickness_max" value="1.3 * Pb_thickness * EMBarrel_rmax/EMBarrel_rmin *
+         cos(InclinationAngle - phi) / cos(InclinationAngle)" />-->
+    <constant name="Pb_thickness_max" value="Pb_thickness"/>
+    <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Steel_thickness" value="0.1*mm"/>
+    <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Glue_thickness" value="0.1*mm"/>
+    <!-- readout in between two absorber plates -->
+    <constant name="readout_thickness" value="1.2*mm"/>
+  </define>
+
+  <display>
+    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true"/>
+  </display>
+
+  <readouts>
+    <!-- readout for the simulation, with the baseline merging: 2x along the module direction in each layer; 4x along theta in each layer except layer 1 -->
+    <!-- the lists mergedCells_Theta and mergedModules define the number of cells to group together in the theta and module direction as a function of the layer -->
+    <readout name="ECalBarrelModuleThetaMerged">
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
+    </readout>
+
+    <!-- example of adding a second readout for the reconstruction, to compare the two -->
+    <readout name="ECalBarrelModuleThetaMerged2">
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
+    </readout>
+  </readouts>
+
+  <detectors>
+    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelModuleThetaMerged">
+      <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
+      <sensitive type="SimpleCalorimeterSD"/>
+      <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
+      <cryostat name="ECAL_Cryo">
+        <material name="Aluminum"/>
+	<dimensions rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoBarrelFront" rmax1="BarCryoECal_rmax-CryoBarrelBack" rmax2="BarCryoECal_rmax" dz="BarCryoECal_dz"/>
+        <front sensitive="false"/> <!-- inner wall of the cryostat -->
+        <side sensitive="false"/> <!-- both sides of the cryostat -->
+        <back sensitive="false"/> <!-- outer wall of the cryostat -->
+      </cryostat>
+      <calorimeter name="EM_barrel">
+        <!-- offset defines the numbering of the modules: module==0 for phi=0 direction -->
+        <dimensions rmin="EMBarrel_rmin" rmax="EMBarrel_rmax" dz="EMBarrel_dz" offset="-InclinationAngle"/>
+        <active thickness="LAr_thickness">
+          <material name="LAr"/>
+          <!-- overlap offset is a specific feature of the construction; do not change! -->
+          <!-- one volume for a gap on both side of the readout) --> 
+          <overlap offset="0.5"/>
+        </active>
+        <passive>
+          <rotation angle="InclinationAngle"/>  <!-- inclination angle -->
+          <inner thickness="Pb_thickness" sensitive="true">
+            <material name="Lead"/>
+          </inner>
+          <innerMax thickness="Pb_thickness_max" sensitive="true">
+            <material name="Lead"/>
+          </innerMax>
+          <glue thickness="Glue_thickness" sensitive="true">
+            <material name="lArCaloGlue"/>
+          </glue>
+          <outer thickness="Steel_thickness" sensitive="true">
+            <material name="lArCaloSteel"/>
+          </outer>
+        </passive>
+        <readout thickness="readout_thickness" sensitive="true">
+          <material name="PCB"/>
+        </readout>
+        <layers> <!-- pcb electrode segmentation in the radial direction -->
+           <layer thickness="1.5*cm" repeat="1"/>
+           <layer thickness="3.5*cm" repeat="11"/>
+        </layers>
+      </calorimeter>
+    </detector>
+  </detectors>
+</lccdd>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_calibration.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_calibration.xml
@@ -15,7 +15,8 @@
     <!-- Inclination angle of the lead plates -->
     <constant name="InclinationAngle" value="50*degree"/>
     <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
-    <constant name="LArGapThickness" value="1.239749*2*mm"/>
+    <!--constant name="LArGapThickness" value="1.239749*2*mm"/-->
+    <constant name="LArGapThickness" value="1.256*2*mm"/>
 
     <!-- Air margin, thicknesses of cryostat and LAr bath -->
     <constant name="AirMarginThickness" value="54*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
@@ -50,7 +51,7 @@
     <!-- When employing trapezoidal planes Pb_thickness corresponds to the minimum thickness, i.e at the front of the calo -->
     <constant name="Pb_thickness" value="1.80*mm"/>
     <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
-    <constant name="ECalBarrelNumPlanes" value="1545"/>
+    <constant name="ECalBarrelNumPlanes" value="1536"/>
     <constant name="ECalBarrelNumLayers" value="12"/>
     <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
     <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
@@ -75,13 +76,13 @@
     <!-- readout for the simulation, with the baseline merging: 2x along the module direction in each layer; 4x along theta in each layer except layer 1 -->
     <!-- the lists mergedCells_Theta and mergedModules define the number of cells to group together in the theta and module direction as a function of the layer -->
     <readout name="ECalBarrelModuleThetaMerged">
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1536" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
 
     <!-- example of adding a second readout for the reconstruction, to compare the two -->
     <readout name="ECalBarrelModuleThetaMerged2">
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1536" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_upstream.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_upstream.xml
@@ -15,7 +15,8 @@
     <!-- Inclination angle of the lead plates -->
     <constant name="InclinationAngle" value="50*degree"/>
     <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
-    <constant name="LArGapThickness" value="1.239749*2*mm"/>
+    <!--constant name="LArGapThickness" value="1.239749*2*mm"/-->
+    <constant name="LArGapThickness" value="1.256*2*mm"/>
 
     <!-- Air margin, thicknesses of cryostat and LAr bath -->
     <constant name="AirMarginThickness" value="54*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
@@ -50,7 +51,7 @@
     <!-- When employing trapezoidal planes Pb_thickness corresponds to the minimum thickness, i.e at the front of the calo -->
     <constant name="Pb_thickness" value="1.80*mm"/>
     <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
-    <constant name="ECalBarrelNumPlanes" value="1545"/>
+    <constant name="ECalBarrelNumPlanes" value="1536"/>
     <constant name="ECalBarrelNumLayers" value="12"/>
     <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
     <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
@@ -75,13 +76,13 @@
     <!-- readout for the simulation, with the baseline merging: 2x along the module direction in each layer; 4x along theta in each layer except layer 1 -->
     <!-- the lists mergedCells_Theta and mergedModules define the number of cells to group together in the theta and module direction as a function of the layer -->
     <readout name="ECalBarrelModuleThetaMerged">
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1536" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
 
     <!-- example of adding a second readout for the reconstruction, to compare the two -->
     <readout name="ECalBarrelModuleThetaMerged2">
-      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1536" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
         <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
     </readout>
   </readouts>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_upstream.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_thetamodulemerged_upstream.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" ?><lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="FCCee_ECalBarrel" title="Settings for FCCee Inclined ECal Barrel Calorimeter" author="M.Aleksa,J.Faltova,A.Zaborowska, V. Volkl" url="no" status="development" version="1.0">
+    <comment>
+      Settings for the inclined EM calorimeter.
+      The barrel is filled with liquid argon. Passive material includes lead in the middle and steal on the outside, glued together.
+      Passive plates are inclined by a certain angle from the radial direction.
+      In between of two passive plates there is a readout.
+      Space between the plate and readout is of trapezoidal shape and filled with liquid argon.
+      Definition of sizes, visualization settings, readout and longitudinal segmentation are specified. 
+    </comment>
+  </info>
+
+  <define><constant name="BarECal_rmax" value="3840*mm"/>
+    <!-- Inclination angle of the lead plates -->
+    <constant name="InclinationAngle" value="50*degree"/>
+    <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
+    <constant name="LArGapThickness" value="1.239749*2*mm"/>
+
+    <!-- Air margin, thicknesses of cryostat and LAr bath -->
+    <constant name="AirMarginThickness" value="54*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
+
+    <constant name="CryoBarrelFrontWarm" value="10*mm"/>   <!-- Al solid corresponding to 0.11 X0 -->
+    <constant name="CryoBarrelFrontCold" value="3.8*mm"/>  <!-- Al solid equivalent of 0.043 X0 sandwich CFRP -->
+    <constant name="CryoBarrelFront" value="CryoBarrelFrontWarm+CryoBarrelFrontCold"/>
+
+    <constant name="CryoBarrelBackCold" value="1100*mm"/>   <!-- Al solid corresponding to 0.34 X0 -->
+    <constant name="CryoBarrelBackWarm" value="2.7*mm"/>  <!-- Al solid equivalent of 0.03 X0 sandwich CFRP -->
+    <constant name="SolenoidBarrel" value="70*mm"/>    <!-- Al solenoid with thickness of 0.8 X0 -->
+    <constant name="CryoBarrelBack" value="CryoBarrelBackWarm+SolenoidBarrel+CryoBarrelBackCold"/>
+
+    <constant name="CryoBarrelSideWarm" value="30*mm"/>
+    <constant name="CryoBarrelSideCold" value="3.8*mm"/>
+    <constant name="CryoBarrelSide" value="CryoBarrelSideWarm+CryoBarrelSideCold"/>
+
+    <constant name="LArBathThicknessFront" value="5*mm"/>
+    <constant name="LArBathThicknessBack" value="40*mm"/>
+
+    <!-- air margin around calorimeter -->
+    <constant name="BarCryoECal_rmin" value="BarECal_rmin+AirMarginThickness"/>
+    <constant name="BarCryoECal_rmax" value="BarECal_rmax-AirMarginThickness"/>
+    <constant name="BarCryoECal_dz" value="BarECal_dz"/>
+    <!-- calorimeter active volume -->
+    <constant name="EMBarrel_rmin" value="BarCryoECal_rmin+CryoBarrelFront+LArBathThicknessFront"/>
+    <constant name="EMBarrel_rmax" value="BarCryoECal_rmax-CryoBarrelBack-LArBathThicknessBack"/>
+    <constant name="EMBarrel_dz" value="BarECal_dz-CryoBarrelSide"/>
+    <!-- thickness of active volume between two absorber plates at EMBarrel_rmin, measuring perpendicular to the readout plate -->
+    <constant name="LAr_thickness" value="LArGapThickness"/>
+    <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
+    <!-- When employing trapezoidal planes Pb_thickness corresponds to the minimum thickness, i.e at the front of the calo -->
+    <constant name="Pb_thickness" value="1.80*mm"/>
+    <constant name="planeLength" value="-EMBarrel_rmin*cos(InclinationAngle) + sqrt(EMBarrel_rmax*EMBarrel_rmax - EMBarrel_rmin*EMBarrel_rmin*sin(InclinationAngle)*sin(InclinationAngle))"/>
+    <constant name="ECalBarrelNumPlanes" value="1545"/>
+    <constant name="ECalBarrelNumLayers" value="12"/>
+    <constant name="phi" value="asin(planeLength / EMBarrel_rmax * sin(InclinationAngle))"/>
+    <!-- use a different value for Pb_thickness_max when employing trapezoidal planes -->
+    <!-- approximate constant sampling fraction: make the absorber grow linearly with the radius,
+         taking into account the angular projection effect -->
+    <!-- <constant name="Pb_thickness_max" value="1.3 * Pb_thickness * EMBarrel_rmax/EMBarrel_rmin *
+         cos(InclinationAngle - phi) / cos(InclinationAngle)" />-->
+    <constant name="Pb_thickness_max" value="Pb_thickness"/>
+    <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Steel_thickness" value="0.1*mm"/>
+    <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Glue_thickness" value="0.1*mm"/>
+    <!-- readout in between two absorber plates -->
+    <constant name="readout_thickness" value="1.2*mm"/>
+  </define>
+
+  <display>
+    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true"/>
+  </display>
+
+  <readouts>
+    <!-- readout for the simulation, with the baseline merging: 2x along the module direction in each layer; 4x along theta in each layer except layer 1 -->
+    <!-- the lists mergedCells_Theta and mergedModules define the number of cells to group together in the theta and module direction as a function of the layer -->
+    <readout name="ECalBarrelModuleThetaMerged">
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="4 1 4 4 4 4 4 4 4 4 4 4" mergedModules="2 2 2 2 2 2 2 2 2 2 2 2" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
+    </readout>
+
+    <!-- example of adding a second readout for the reconstruction, to compare the two -->
+    <readout name="ECalBarrelModuleThetaMerged2">
+      <segmentation type="FCCSWGridModuleThetaMerged" nModules="1545" mergedCells_Theta="2 4 2 1 2 1 2 2 1 1 1 2" mergedModules="2 1 1 2 2 1 1 1 2 2 1 1" grid_size_theta="0.009817477/4" offset_theta="0.5902785"/>
+        <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:10</id>
+    </readout>
+  </readouts>
+
+  <detectors>
+    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelModuleThetaMerged">
+      <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
+      <sensitive type="SimpleCalorimeterSD"/>
+      <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
+      <cryostat name="ECAL_Cryo">
+        <material name="Aluminum"/>
+	<dimensions rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoBarrelFront" rmax1="BarCryoECal_rmax-CryoBarrelBack" rmax2="BarCryoECal_rmax" dz="BarCryoECal_dz"/>
+        <front sensitive="true"/> <!-- inner wall of the cryostat -->
+        <side sensitive="true"/> <!-- both sides of the cryostat -->
+        <back sensitive="true"/> <!-- outer wall of the cryostat -->
+      </cryostat>
+      <calorimeter name="EM_barrel">
+        <!-- offset defines the numbering of the modules: module==0 for phi=0 direction -->
+        <dimensions rmin="EMBarrel_rmin" rmax="EMBarrel_rmax" dz="EMBarrel_dz" offset="-InclinationAngle"/>
+        <active thickness="LAr_thickness">
+          <material name="LAr"/>
+          <!-- overlap offset is a specific feature of the construction; do not change! -->
+          <!-- one volume for a gap on both side of the readout) --> 
+          <overlap offset="0.5"/>
+        </active>
+        <passive>
+          <rotation angle="InclinationAngle"/>  <!-- inclination angle -->
+          <inner thickness="Pb_thickness" sensitive="false">
+            <material name="Lead"/>
+          </inner>
+          <innerMax thickness="Pb_thickness_max" sensitive="false">
+            <material name="Lead"/>
+          </innerMax>
+          <glue thickness="Glue_thickness" sensitive="false">
+            <material name="lArCaloGlue"/>
+          </glue>
+          <outer thickness="Steel_thickness" sensitive="false">
+            <material name="lArCaloSteel"/>
+          </outer>
+        </passive>
+        <readout thickness="readout_thickness" sensitive="false">
+          <material name="PCB"/>
+        </readout>
+        <layers> <!-- pcb electrode segmentation in the radial direction -->
+           <layer thickness="1.5*cm" repeat="1"/>
+           <layer thickness="3.5*cm" repeat="11"/>
+        </layers>
+      </calorimeter>
+    </detector>
+  </detectors>
+</lccdd>

--- a/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
+++ b/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
@@ -205,6 +205,11 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
   uint numPlanes =
       round(M_PI / asin((passiveThickness + activeThickness + readoutThickness) / (2. * caloDim.rmin() * cos(angle))));
 
+  double dPhi = 2. * M_PI / numPlanes;
+  lLog << MSG::INFO << "number of passive plates = " << numPlanes << " azim. angle difference =  " << dPhi << endmsg;
+  lLog << MSG::INFO << " distance at inner radius (cm) = " << 2. * M_PI * caloDim.rmin() / numPlanes << "\n"
+       << " distance at outer radius (cm) = " << 2. * M_PI * caloDim.rmax() / numPlanes << endmsg;
+
   // The following code checks if the xml geometry file contains a constant defining
   // the number of planes in the barrel. In that case, it makes the program abort
   // if the number of planes in the xml is different from the one calculated from
@@ -227,10 +232,6 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
     // make the code crash (incidentSvc does not work)
      assert(nModules == numPlanes);
   }
-  double dPhi = 2. * M_PI / numPlanes;
-  lLog << MSG::INFO << "number of passive plates = " << numPlanes << " azim. angle difference =  " << dPhi << endmsg;
-  lLog << MSG::INFO << " distance at inner radius (cm) = " << 2. * M_PI * caloDim.rmin() / numPlanes << "\n"
-       << " distance at outer radius (cm) = " << 2. * M_PI * caloDim.rmax() / numPlanes << endmsg;
   // Readout is in the middle between two passive planes
   double offsetPassivePhi = caloDim.offset() + dPhi / 2.;
   double offsetReadoutPhi = caloDim.offset() + 0;

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -100,9 +100,9 @@ protected:
   std::string m_layerID;
   /// the field name used for the read-out module (can differ from module due to merging)
   std::string m_moduleID;
-  /// vector of number of cells to be merged along theta for each layer
+  /// vector of number of cells to be merged along theta for each layer (typically between 1 and 4)
   std::vector<int> m_mergedCellsTheta;
-  /// vector of number of modules to be merged for each layer
+  /// vector of number of modules to be merged for each layer (typically 1 or 2)
   std::vector<int> m_mergedModules;
 
   /// number of modules (or, equivalently, the deltaPhi between adjacent modules)

--- a/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/FCCSWGridModuleThetaMerged.h
@@ -63,7 +63,7 @@ public:
    *   return The number of merged cells in theta
    */
   inline int mergedThetaCells(const int layer) const {
-    if (layer<m_mergedCellsTheta.size())
+    if (layer < (int) m_mergedCellsTheta.size())
       return m_mergedCellsTheta[layer];
     else
       return 1;
@@ -73,7 +73,7 @@ public:
    *   return The number of merged modules
    */
   inline int mergedModules(const int layer) const {
-    if (layer<m_mergedModules.size())
+    if (layer < (int) m_mergedModules.size())
       return m_mergedModules[layer];
     else
       return 1;


### PR DESCRIPTION
This PR and related ones for FCCDetectors and LAr_scripts make topoclustering work with the new theta-module readout for the FCC-ee calorimeter.
I would like to initiate the review to discuss the code structure - I will then remove commented code and debug messages later. 

The PR also contain a couple of fixes to what I think are bugs in the current code, and removes warning in FCCSWGridModuleThetaMerged.h from a int vs uint comparison

Related PRs: 
https://github.com/HEP-FCC/k4RecCalorimeter/pull/51
https://github.com/BrieucF/LAr_scripts/pull/13

Tagging @gartrog @BrieucF @dasphy