### PR TITLE
Fix the installation of the DetTrackerSimple compact folder

### DIFF
--- a/Detector/DetTrackerSimple/CMakeLists.txt
+++ b/Detector/DetTrackerSimple/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Package: DetTrackerSimple
 ################################################################################
 
-install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/compact DESTINATION Detector/DetTrackerSimple)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/compact DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/Detector/DetTrackerSimple)
 
 file(GLOB sources src/*.cpp)
 add_dd4hep_plugin(DetTrackerSimple SHARED ${sources})


### PR DESCRIPTION
Currently installed in the main directory, while all the other folders are being installed in `share/`. Tree of folders:

```
./Detector
./Detector/DetTrackerSimple
./Detector/DetTrackerSimple/compact
./share
./share/FCCDetectors
./share/FCCDetectors/Detector
./share/FCCDetectors/Detector/DetFCCeeECalInclined
./share/FCCDetectors/Detector/DetFCCeeECalInclined/compact
./share/FCCDetectors/Detector/DetFCCeeECalInclined/compact/o1_v01
./share/FCCDetectors/Detector/DetFCChhECalSimple
./share/FCCDetectors/Detector/DetFCChhECalSimple/compact
./share/FCCDetectors/Detector/DetFCCeeIDEA
./share/FCCDetectors/Detector/DetFCCeeIDEA/compact
./share/FCCDetectors/Detector/DetFCCeeIDEA/compact/IDEA_o1_v01

```