### PR TITLE
Add detector_types.xml in a few detectors

### DIFF
--- a/Detector/DetFCCeeCLD/compact/FCCee_o2_v02/FCCee_o2_v02.xml
+++ b/Detector/DetFCCeeCLD/compact/FCCee_o2_v02/FCCee_o2_v02.xml
@@ -29,6 +29,8 @@
     <constant name="world_z" value="world_size"/>
   </define>
 
+  <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
   <include ref="./FCCee_DectDimensions.xml" />
 
   <include ref="../../../DetFCCeeCommon/compact/Beampipe.xml"/>

--- a/Detector/DetFCCeeIDEA/compact/FCCee_DectMaster.xml
+++ b/Detector/DetFCCeeIDEA/compact/FCCee_DectMaster.xml
@@ -28,6 +28,8 @@
     <constant name="world_z" value="world_size"/>
   </define>
 
+  <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
   <include ref="./FCCee_DectDimensions.xml" />
 
   <include ref="Beampipe.xml"/>


### PR DESCRIPTION
These detectors are used in FCCSW, and the tests are currently failing because they are missing the definitions in `detector_types.xml`. Error message:

```
2026-04-22T20:08:01.8035195Z Compact          INFO  ++ Converted subdetector:Vertex of type DD4hep_SubdetectorAssembly 
2026-04-22T20:08:01.8036166Z terminate called after throwing an instance of 'std::runtime_error'
2026-04-22T20:08:01.8037897Z   what():  dd4hep: Evaluator::Object : unknown variable : DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_BARREL : value=DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_BARREL [Evaluation error]
```